### PR TITLE
Add FF config defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ You can configure the Functions Framework using the environment variables shown 
 | Environment variable      | Description
 | ------------------------- | -----------
 | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests.
-| `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Can be either `http` or `event`. Default: `http`
-| `FUNCTION_SOURCE` | The name of the file containing the source code for your function to load. By default the file **index.php** is loaded in the application root if it exists.
+| `FUNCTION_SOURCE` | The name of the file containing the source code for your function to load. Default: **`index.php`** (if it exists)
+| `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Can be either `http` or `event`. Default: **`http`**
 
 # Enable CloudEvents
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ You can configure the Functions Framework using the environment variables shown 
 | Environment variable      | Description
 | ------------------------- | -----------
 | `FUNCTION_TARGET`         | The name of the exported function to be invoked in response to requests.
-| `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Can be either `http` or `event`.
+| `FUNCTION_SIGNATURE_TYPE` | The signature used when writing your function. Controls unmarshalling rules and determines which arguments are used to invoke your function. Can be either `http` or `event`. Default: `http`
 | `FUNCTION_SOURCE` | The name of the file containing the source code for your function to load. By default the file **index.php** is loaded in the application root if it exists.
 
 # Enable CloudEvents

--- a/router.php
+++ b/router.php
@@ -58,17 +58,11 @@ if ($functionSource = getenv('FUNCTION_SOURCE', true)) {
  */
 (function () {
     $target = getenv('FUNCTION_TARGET', true);
-    if (false === $target) {
-        $target = 'function';
-    }
     if (!is_callable($target)) {
         throw new InvalidArgumentException(sprintf(
             'Function target is not callable: "%s"', $target));
     }
-    $signatureType = getenv('FUNCTION_SIGNATURE_TYPE', true);
-    if (false === $signatureType) {
-        $signatureType = 'http';
-    }
+    $signatureType = getenv('FUNCTION_SIGNATURE_TYPE', true) ?: 'http';
 
     $invoker = new Google\CloudFunctions\Invoker($target, $signatureType);
     $invoker->handle()->send();

--- a/router.php
+++ b/router.php
@@ -58,10 +58,14 @@ if ($functionSource = getenv('FUNCTION_SOURCE', true)) {
  */
 (function () {
     $target = getenv('FUNCTION_TARGET', true);
+    if (false === $target) {
+        throw new RuntimeException('FUNCTION_TARGET is not set');
+    }
     if (!is_callable($target)) {
         throw new InvalidArgumentException(sprintf(
             'Function target is not callable: "%s"', $target));
     }
+
     $signatureType = getenv('FUNCTION_SIGNATURE_TYPE', true) ?: 'http';
 
     $invoker = new Google\CloudFunctions\Invoker($target, $signatureType);

--- a/router.php
+++ b/router.php
@@ -59,7 +59,7 @@ if ($functionSource = getenv('FUNCTION_SOURCE', true)) {
 (function () {
     $target = getenv('FUNCTION_TARGET', true);
     if (false === $target) {
-        throw new RuntimeException('FUNCTION_TARGET is not set');
+        $target = 'function';
     }
     if (!is_callable($target)) {
         throw new InvalidArgumentException(sprintf(
@@ -67,7 +67,7 @@ if ($functionSource = getenv('FUNCTION_SOURCE', true)) {
     }
     $signatureType = getenv('FUNCTION_SIGNATURE_TYPE', true);
     if (false === $signatureType) {
-        throw new RuntimeException('FUNCTION_SIGNATURE_TYPE is not set');
+        $signatureType = 'http'
     }
 
     $invoker = new Google\CloudFunctions\Invoker($target, $signatureType);

--- a/router.php
+++ b/router.php
@@ -67,7 +67,7 @@ if ($functionSource = getenv('FUNCTION_SOURCE', true)) {
     }
     $signatureType = getenv('FUNCTION_SIGNATURE_TYPE', true);
     if (false === $signatureType) {
-        $signatureType = 'http'
+        $signatureType = 'http';
     }
 
     $invoker = new Google\CloudFunctions\Invoker($target, $signatureType);

--- a/tests/routerTest.php
+++ b/tests/routerTest.php
@@ -34,28 +34,6 @@ class routerTest extends TestCase
         require 'router.php';
     }
 
-    public function testInvalidFunctionTarget()
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('FUNCTION_TARGET is not set');
-
-        putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');
-        putenv('FUNCTION_TARGET');
-        putenv('FUNCTION_SIGNATURE_TYPE');
-        require 'router.php';
-    }
-
-    public function testInvalidFunctionSignatureType()
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('FUNCTION_SIGNATURE_TYPE is not set');
-
-        putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');
-        putenv('FUNCTION_TARGET=helloHttp');
-        putenv('FUNCTION_SIGNATURE_TYPE');
-        require 'router.php';
-    }
-
     public function testRouterInvokedSuccessfully()
     {
         putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');

--- a/tests/routerTest.php
+++ b/tests/routerTest.php
@@ -26,6 +26,25 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class routerTest extends TestCase
 {
+    public function testInvalidFunctionTarget()	
+    {	
+        $this->expectException('RuntimeException');	
+        $this->expectExceptionMessage('FUNCTION_TARGET is not set');	
+        putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');	
+        putenv('FUNCTION_TARGET');	
+        putenv('FUNCTION_SIGNATURE_TYPE=http');	
+        require 'router.php';
+    }
+    
+    public function testDefaultFunctionSignatureType()	
+    {	
+        putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');
+        putenv('FUNCTION_TARGET=Google\CloudFunctions\Tests\test_callable');
+        require 'router.php';
+
+        $this->expectOutputString('Invoked!');
+    }
+    
     public function testInvalidFunctionSource()
     {
         $this->expectException('RuntimeException');

--- a/tests/routerTest.php
+++ b/tests/routerTest.php
@@ -26,18 +26,18 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class routerTest extends TestCase
 {
-    public function testInvalidFunctionTarget()	
-    {	
-        $this->expectException('RuntimeException');	
-        $this->expectExceptionMessage('FUNCTION_TARGET is not set');	
-        putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');	
-        putenv('FUNCTION_TARGET');	
-        putenv('FUNCTION_SIGNATURE_TYPE=http');	
+    public function testInvalidFunctionTarget()
+    {
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('FUNCTION_TARGET is not set');
+        putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');
+        putenv('FUNCTION_TARGET');
+        putenv('FUNCTION_SIGNATURE_TYPE=http');
         require 'router.php';
     }
     
-    public function testDefaultFunctionSignatureType()	
-    {	
+    public function testDefaultFunctionSignatureType()
+    {
         putenv('FUNCTION_SOURCE=' . __DIR__ . '/../examples/hello/index.php');
         putenv('FUNCTION_TARGET=Google\CloudFunctions\Tests\test_callable');
         require 'router.php';


### PR DESCRIPTION
Adds defaults for `FUNCTION_TARGET` and `FUNCTION_SIGNATURE_TYPE`.

This was detected when following the generic FF Docker guide and seeing errors when these env vars were not included.