### PR TITLE
fix: better type-handing in Context class

### DIFF
--- a/src/CloudEvent.php
+++ b/src/CloudEvent.php
@@ -98,8 +98,19 @@ class CloudEvent
 
     public static function fromArray(array $arr)
     {
-        $argKeys = ['id', 'source', 'specversion', 'type', 'datacontenttype', 'dataschema', 'subject', 'time', 'data'];
         $args = [];
+        $argKeys = [
+            'id',
+            'source',
+            'specversion',
+            'type',
+            'datacontenttype',
+            'dataschema',
+            'subject',
+            'time',
+            'data'
+        ];
+
         foreach ($argKeys as $key) {
             $args[] = $arr[$key] ?? null;
         }

--- a/src/Context.php
+++ b/src/Context.php
@@ -19,23 +19,47 @@ namespace Google\CloudFunctions;
 
 class Context
 {
-    public $eventId;
-    public $timestamp;
-    public $eventType;
-    public $resource;
+    private $eventId;
+    private $timestamp;
+    private $eventType;
+    private $resource;
 
-    public function __construct($eventId, $timestamp, $eventType, $resource)
-    {
+    public function __construct(
+        ?string $eventId,
+        ?string $timestamp,
+        ?string $eventType,
+        ?string $resource
+    ) {
         $this->eventId = $eventId;
         $this->timestamp = $timestamp;
         $this->eventType = $eventType;
         $this->resource = $resource;
     }
 
+    public function getEventId(): ?string
+    {
+        return $this->eventId;
+    }
+
+    public function getEventType(): ?string
+    {
+        return $this->eventType;
+    }
+
+    public function getTimestamp(): ?string
+    {
+        return $this->timestamp;
+    }
+
+    public function getResource(): ?string
+    {
+        return $this->resource;
+    }
+
     public static function fromArray(array $arr)
     {
-        $argKeys = ['eventId', 'timestamp', 'eventType', 'resource'];
         $args = [];
+        $argKeys = ['eventId', 'timestamp', 'eventType', 'resource'];
         foreach ($argKeys as $key) {
             $args[] = $arr[$key] ?? null;
         }

--- a/tests/BackgroundFunctionWrapperTest.php
+++ b/tests/BackgroundFunctionWrapperTest.php
@@ -81,9 +81,9 @@ class BackgroundFunctionWrapperTest extends TestCase
     {
         self::$functionCalled = true;
         $this->assertEquals('foo', $data);
-        $this->assertEquals('abc', $context->eventId);
-        $this->assertEquals('def', $context->timestamp);
-        $this->assertEquals('ghi', $context->eventType);
-        $this->assertEquals('jkl', $context->resource);
+        $this->assertEquals('abc', $context->getEventId());
+        $this->assertEquals('def', $context->getTimestamp());
+        $this->assertEquals('ghi', $context->getEventType());
+        $this->assertEquals('jkl', $context->getResource());
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -33,18 +33,18 @@ class ContextTest extends TestCase
             'eventType' => 'ghi',
             'resource' => 'jkl',
         ]);
-        $this->assertEquals('abc', $context->eventId);
-        $this->assertEquals('def', $context->timestamp);
-        $this->assertEquals('ghi', $context->eventType);
-        $this->assertEquals('jkl', $context->resource);
+        $this->assertEquals('abc', $context->getEventId());
+        $this->assertEquals('def', $context->getTimestamp());
+        $this->assertEquals('ghi', $context->getEventType());
+        $this->assertEquals('jkl', $context->getResource());
     }
 
     public function testFromEmptyArray()
     {
         $context = Context::fromArray([]);
-        $this->assertEquals(null, $context->eventId);
-        $this->assertEquals(null, $context->timestamp);
-        $this->assertEquals(null, $context->eventType);
-        $this->assertEquals(null, $context->resource);
+        $this->assertEquals(null, $context->getEventId());
+        $this->assertEquals(null, $context->getTimestamp());
+        $this->assertEquals(null, $context->getEventType());
+        $this->assertEquals(null, $context->getResource());
     }
 }


### PR DESCRIPTION
Improve typing in Context class by removing public properties and making it immutable. Modeled after the [CloudEvent](https://github.com/GoogleCloudPlatform/functions-framework-php/blob/master/src/CloudEvent.php) class