### PR TITLE
ci: split CI workflows. Standardize CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,11 +1,5 @@
-name: Lint
-
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-
+name: PHP Lint CI
+on: [push, pull_request]
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,5 @@
 name: PHP Lint CI
-on: [push, pull_request]
+on: [push]
 jobs:
   php-cs-fixer:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,5 +1,5 @@
 name: PHP Unit CI
-on: [push, pull_request]
+on: [push]
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,13 +1,7 @@
-name: Test Suite
-
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-
+name: PHP Unit CI
+on: [push, pull_request]
 jobs:
-  run:
+  build:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
@@ -17,8 +11,7 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-
-    - name: Setup PHP
+    - name: Uses PHP ${{ matrix.php-versions }}
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}


### PR DESCRIPTION
- Standardizes `unit` for the unit tests workflow
- Uses simpler branch setting
- Minor formatting