### PR TITLE
feat: add better handling for exceptions

### DIFF
--- a/src/CloudEventFunctionWrapper.php
+++ b/src/CloudEventFunctionWrapper.php
@@ -121,6 +121,11 @@ class CloudEventFunctionWrapper extends FunctionWrapper
         return CloudEvent::fromArray($content);
     }
 
+    public function errorStatusHeader(): string
+    {
+        return 'error';
+    }
+
     protected function getFunctionParameterClassName(): string
     {
         return CloudEvent::class;

--- a/src/CloudEventFunctionWrapper.php
+++ b/src/CloudEventFunctionWrapper.php
@@ -42,23 +42,37 @@ class CloudEventFunctionWrapper extends FunctionWrapper
 
     public function execute(ServerRequestInterface $request): ResponseInterface
     {
+        $body = (string) $request->getBody();
+        $jsonData = json_decode($body, true);
+
+        // Validate JSON, return 400 Bad Request on error
+        if (json_last_error() != JSON_ERROR_NONE) {
+            return new Response(400, [
+                self::FUNCTION_STATUS_HEADER => 'crash'
+            ], sprintf(
+                'Could not parse CloudEvent: %s',
+                '' !== $body ? json_last_error_msg() : 'Missing cloudevent payload'
+            ));
+        }
+
         switch ($this->getEventType($request)) {
             case self::TYPE_LEGACY:
                 $mapper = new LegacyEventMapper();
-                $cloudevent = $mapper->fromRequest($request);
+                $cloudevent = $mapper->fromJsonData($jsonData);
                 break;
 
             case self::TYPE_STRUCTURED:
-                $cloudevent = $this->fromStructuredRequest($request);
+                $cloudevent = CloudEvent::fromArray($jsonData);
                 break;
 
             case self::TYPE_BINARY:
-                $cloudevent = $this->fromBinaryRequest($request);
+                $cloudevent = $this->fromBinaryRequest($request, $jsonData);
                 break;
 
             default:
-                throw new LogicException('Invalid event type');
-                break;
+                return new Response(400, [
+                    self::FUNCTION_STATUS_HEADER => 'crash'
+                ], 'invalid event type');
         }
 
         call_user_func($this->function, $cloudevent);
@@ -81,34 +95,10 @@ class CloudEventFunctionWrapper extends FunctionWrapper
         }
     }
 
-    private function parseJsonData(ServerRequestInterface $request)
-    {
-        // Get Body
-        $body = (string) $request->getBody();
-
-        $jsonData = json_decode($body, true);
-        if (json_last_error() != JSON_ERROR_NONE) {
-            throw new RuntimeException(sprintf(
-                'Could not parse CloudEvent: %s',
-                '' !== $body ? json_last_error_msg() : 'Missing cloudevent payload'
-            ));
-        }
-
-        return $jsonData;
-    }
-
-    private function fromStructuredRequest(
-        ServerRequestInterface $request
-    ): CloudEvent {
-        $jsonData = $this->parseJsonData($request);
-        return CloudEvent::fromArray($jsonData);
-    }
-
     private function fromBinaryRequest(
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
+        $jsonData
     ): CloudEvent {
-        $jsonData = $this->parseJsonData($request);
-
         $content = [];
 
         foreach (self::$validKeys as $key) {

--- a/src/CloudEventFunctionWrapper.php
+++ b/src/CloudEventFunctionWrapper.php
@@ -20,8 +20,6 @@ namespace Google\CloudFunctions;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use LogicException;
-use RuntimeException;
 
 class CloudEventFunctionWrapper extends FunctionWrapper
 {

--- a/src/CloudEventFunctionWrapper.php
+++ b/src/CloudEventFunctionWrapper.php
@@ -121,11 +121,6 @@ class CloudEventFunctionWrapper extends FunctionWrapper
         return CloudEvent::fromArray($content);
     }
 
-    public function errorStatusHeader(): string
-    {
-        return 'error';
-    }
-
     protected function getFunctionParameterClassName(): string
     {
         return CloudEvent::class;

--- a/src/FunctionWrapper.php
+++ b/src/FunctionWrapper.php
@@ -48,8 +48,6 @@ abstract class FunctionWrapper
 
     abstract protected function getFunctionParameterClassName(): string;
 
-    abstract public function errorStatusHeader(): string;
-
     private function getFunctionReflection(
         callable $function
     ): ReflectionFunctionAbstract {

--- a/src/FunctionWrapper.php
+++ b/src/FunctionWrapper.php
@@ -38,8 +38,6 @@ abstract class FunctionWrapper
         );
 
         $this->function = $function;
-
-        // TODO: validate function signature, if present.
     }
 
     abstract public function execute(

--- a/src/FunctionWrapper.php
+++ b/src/FunctionWrapper.php
@@ -27,6 +27,8 @@ use ReflectionMethod;
 
 abstract class FunctionWrapper
 {
+    const FUNCTION_STATUS_HEADER = 'X-Google-Status';
+
     protected $function;
 
     public function __construct(callable $function, array $signature = null)
@@ -45,6 +47,8 @@ abstract class FunctionWrapper
     ): ResponseInterface;
 
     abstract protected function getFunctionParameterClassName(): string;
+
+    abstract public function errorStatusHeader(): string;
 
     private function getFunctionReflection(
         callable $function

--- a/src/HttpFunctionWrapper.php
+++ b/src/HttpFunctionWrapper.php
@@ -43,7 +43,7 @@ class HttpFunctionWrapper extends FunctionWrapper
             return $response;
         }
 
-        throw new \UnexpectedValueException(
+        throw new \LogicException(
             'Function response must be string or ' . ResponseInterface::class
         );
     }

--- a/src/HttpFunctionWrapper.php
+++ b/src/HttpFunctionWrapper.php
@@ -48,11 +48,6 @@ class HttpFunctionWrapper extends FunctionWrapper
         );
     }
 
-    public function errorStatusHeader(): string
-    {
-        return 'crash';
-    }
-
     protected function getFunctionParameterClassName(): string
     {
         return ServerRequestInterface::class;

--- a/src/HttpFunctionWrapper.php
+++ b/src/HttpFunctionWrapper.php
@@ -38,10 +38,19 @@ class HttpFunctionWrapper extends FunctionWrapper
         $response = call_user_func($this->function, $request);
 
         if (is_string($response)) {
-            $response = new Response(200, [], $response);
+            return new Response(200, [], $response);
+        } elseif ($response instanceof ResponseInterface) {
+            return $response;
         }
 
-        return $response;
+        throw new \UnexpectedValueException(
+            'Function response must be string or ' . ResponseInterface::class
+        );
+    }
+
+    public function errorStatusHeader(): string
+    {
+        return 'crash';
     }
 
     protected function getFunctionParameterClassName(): string

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -18,6 +18,7 @@
 namespace Google\CloudFunctions;
 
 use InvalidArgumentException;
+use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -25,6 +26,7 @@ use Psr\Http\Message\ServerRequestInterface;
 class Invoker
 {
     private $function;
+    private $errorLogFunc;
 
     /**
      * @param $target callable The callable to be invoked
@@ -44,6 +46,12 @@ class Invoker
             throw new InvalidArgumentException(sprintf(
                 'Invalid signature type: "%s"', $signatureType));
         }
+        $this->errorLogFunc = function (string $error) {
+            fwrite(fopen('php://stderr', 'wb'), json_encode([
+              'message' => $error,
+              'severity' => 'error'
+            ]));
+        };
     }
 
     public function handle(
@@ -53,6 +61,15 @@ class Invoker
             $request = ServerRequest::fromGlobals();
         }
 
-        return $this->function->execute($request);
+        try {
+            return $this->function->execute($request);
+        } catch (\Exception $e) {
+            // Log the full error and stack trace
+            ($this->errorLogFunc)((string) $e);
+            $statusHeader = $this->function->errorStatusHeader();
+            return new Response(200, [
+                FunctionWrapper::FUNCTION_STATUS_HEADER => $statusHeader,
+            ], $e->getMessage());
+        }
     }
 }

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -50,7 +50,7 @@ class Invoker
             fwrite(fopen('php://stderr', 'wb'), json_encode([
               'message' => $error,
               'severity' => 'error'
-            ]));
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         };
     }
 

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -71,7 +71,7 @@ class Invoker
             $statusHeader = $this->function instanceof HttpFunctionWrapper
                 ? 'crash'
                 : 'error';
-            return new Response(200, [
+            return new Response(500, [
                 FunctionWrapper::FUNCTION_STATUS_HEADER => $statusHeader,
             ], $e->getMessage());
         }

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -73,7 +73,7 @@ class Invoker
                 : 'error';
             return new Response(500, [
                 FunctionWrapper::FUNCTION_STATUS_HEADER => $statusHeader,
-            ], $e->getMessage());
+            ]);
         }
     }
 }

--- a/src/Invoker.php
+++ b/src/Invoker.php
@@ -66,7 +66,11 @@ class Invoker
         } catch (\Exception $e) {
             // Log the full error and stack trace
             ($this->errorLogFunc)((string) $e);
-            $statusHeader = $this->function->errorStatusHeader();
+            // Set "X-Google-Status" to "crash" for Http functions and "error"
+            // for Cloud Events
+            $statusHeader = $this->function instanceof HttpFunctionWrapper
+                ? 'crash'
+                : 'error';
             return new Response(200, [
                 FunctionWrapper::FUNCTION_STATUS_HEADER => $statusHeader,
             ], $e->getMessage());

--- a/src/LegacyEventMapper.php
+++ b/src/LegacyEventMapper.php
@@ -17,11 +17,10 @@
 
 namespace Google\CloudFunctions;
 
-use RuntimeException;
-
 class LegacyEventMapper
 {
-    public function fromJsonData(array $jsonData): CloudEvent {
+    public function fromJsonData(array $jsonData): CloudEvent
+    {
         list($context, $data) = $this->getLegacyEventContextAndData($jsonData);
 
         $eventType = $context->getEventType();
@@ -55,7 +54,8 @@ class LegacyEventMapper
         ]);
     }
 
-    private function getLegacyEventContextAndData(array $jsonData): array {
+    private function getLegacyEventContextAndData(array $jsonData): array
+    {
         $data = $jsonData['data'] ?? null;
 
         if (array_key_exists('context', $jsonData)) {

--- a/src/LegacyEventMapper.php
+++ b/src/LegacyEventMapper.php
@@ -17,15 +17,12 @@
 
 namespace Google\CloudFunctions;
 
-use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 
 class LegacyEventMapper
 {
-    public function fromRequest(
-        ServerRequestInterface $request
-    ): CloudEvent {
-        list($context, $data) = $this->getLegacyEventContextAndData($request);
+    public function fromJsonData(array $jsonData): CloudEvent {
+        list($context, $data) = $this->getLegacyEventContextAndData($jsonData);
 
         $eventType = $context->getEventType();
         $resourceName = $context->getResourceName();
@@ -58,27 +55,7 @@ class LegacyEventMapper
         ]);
     }
 
-    private function parseJsonData(ServerRequestInterface $request)
-    {
-        // Get Body
-        $body = (string) $request->getBody();
-
-        $jsonData = json_decode($body, true);
-        if (json_last_error() != JSON_ERROR_NONE) {
-            throw new RuntimeException(sprintf(
-                'Could not parse request body: %s',
-                '' !== $body ? json_last_error_msg() : 'Missing event payload'
-            ));
-        }
-
-        return $jsonData;
-    }
-
-    private function getLegacyEventContextAndData(
-        ServerRequestInterface $request
-    ): array {
-        $jsonData = $this->parseJsonData($request);
-
+    private function getLegacyEventContextAndData(array $jsonData): array {
         $data = $jsonData['data'] ?? null;
 
         if (array_key_exists('context', $jsonData)) {

--- a/tests/CloudEventFunctionsWrapperTest.php
+++ b/tests/CloudEventFunctionsWrapperTest.php
@@ -37,21 +37,29 @@ class CloudEventFunctionWrapperTest extends TestCase
 
     public function testInvalidCloudEventRequestBody()
     {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('Could not parse CloudEvent: Syntax error');
         $headers = ['content-type' => 'application/cloudevents+json'];
         $request = new ServerRequest('POST', '/', $headers, 'notjson');
         $cloudEventFunctionWrapper = new CloudEventFunctionWrapper([$this, 'invokeThis']);
-        $cloudEventFunctionWrapper->execute($request);
+        $response = $cloudEventFunctionWrapper->execute($request);
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(
+            'Could not parse CloudEvent: Syntax error',
+            (string) $response->getBody()
+        );
+        $this->assertEquals('crash', $response->getHeaderLine('X-Google-Status'));
     }
 
     public function testInvalidLegacyEventRequestBody()
     {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('Could not parse request body: Syntax error');
         $request = new ServerRequest('POST', '/', [], 'notjson');
         $cloudEventFunctionWrapper = new CloudEventFunctionWrapper([$this, 'invokeThis']);
-        $cloudEventFunctionWrapper->execute($request);
+        $response = $cloudEventFunctionWrapper->execute($request);
+        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(
+            'Could not parse CloudEvent: Syntax error',
+            (string) $response->getBody()
+        );
+        $this->assertEquals('crash', $response->getHeaderLine('X-Google-Status'));
     }
 
     public function testNoFunctionParameters()

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -65,7 +65,7 @@ class InvokerTest extends TestCase
         $response = $invoker->handle($request);
 
         // Verify the error message response
-        $this->assertEquals((string) $response->getBody(), 'This is an error');
+        $this->assertEquals('', (string) $response->getBody());
         $this->assertEquals(500, $response->getStatusCode());
         $this->assertTrue(
             $response->hasHeader(FunctionWrapper::FUNCTION_STATUS_HEADER)
@@ -103,7 +103,7 @@ class InvokerTest extends TestCase
         throw new \Exception('This is an error');
     }
 
-    public function invokeCloudEventError(CloudEvent $event)
+    public function invokeCloudeventError(CloudEvent $event)
     {
         throw new \Exception('This is an error');
     }

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -66,7 +66,7 @@ class InvokerTest extends TestCase
 
         // Verify the error message response
         $this->assertEquals((string) $response->getBody(), 'This is an error');
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(500, $response->getStatusCode());
         $this->assertTrue(
             $response->hasHeader(FunctionWrapper::FUNCTION_STATUS_HEADER)
         );

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -17,9 +17,13 @@
 
 namespace Google\CloudFunctions\Tests;
 
+use Google\CloudFunctions\CloudEvent;
 use Google\CloudFunctions\Invoker;
+use Google\CloudFunctions\FunctionWrapper;
+use GuzzleHttp\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
 
 /**
  * @group gcf-framework
@@ -40,8 +44,67 @@ class InvokerTest extends TestCase
         $this->assertEquals((string) $response->getBody(), 'Invoked!');
     }
 
+    /**
+     * @dataProvider provideErrorHandling
+     */
+    public function testErrorHandling($signatureType, $errorStatus, $request = null)
+    {
+        $functionName = sprintf('invoke%sError', ucwords($signatureType));
+        $invoker = new Invoker([$this, $functionName], $signatureType);
+        // use a custom error log func
+        $message = null;
+        $newErrorLogFunc = function (string $error) use (&$message) {
+            $message = $error;
+        };
+        $errorLogFuncProp = (new ReflectionClass($invoker))
+            ->getProperty('errorLogFunc');
+        $errorLogFuncProp->setAccessible(true);
+        $errorLogFuncProp->setValue($invoker, $newErrorLogFunc);
+
+        // Invoke the handler
+        $response = $invoker->handle($request);
+
+        // Verify the error message response
+        $this->assertEquals((string) $response->getBody(), 'This is an error');
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertTrue(
+            $response->hasHeader(FunctionWrapper::FUNCTION_STATUS_HEADER)
+        );
+        $this->assertEquals(
+            $errorStatus,
+            $response->getHeaderLine(FunctionWrapper::FUNCTION_STATUS_HEADER)
+        );
+        // Verify the log output
+        $this->assertNotNull($message);
+        $this->assertStringContainsString('Exception: This is an error', $message);
+        $this->assertStringContainsString('InvokerTest.php', $message); // stack trace
+    }
+
+    public function provideErrorHandling()
+    {
+        return [
+            ['http', 'crash'],
+            ['cloudevent', 'error', new ServerRequest(
+                'POST',
+                '',
+                [],
+                '{"eventId":"foo","eventType":"bar","resource":"baz"}'
+            )],
+        ];
+    }
+
     public function invokeThis(ServerRequestInterface $request)
     {
         return 'Invoked!';
+    }
+
+    public function invokeHttpError(ServerRequestInterface $request)
+    {
+        throw new \Exception('This is an error');
+    }
+
+    public function invokeCloudEventError(CloudEvent $event)
+    {
+        throw new \Exception('This is an error');
     }
 }

--- a/tests/LegacyEventMapperTest.php
+++ b/tests/LegacyEventMapperTest.php
@@ -27,19 +27,10 @@ use GuzzleHttp\Psr7\ServerRequest;
  */
 class LegacyEventMapperTest extends TestCase
 {
-    public function testInvalidRequestBody()
-    {
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('Could not parse request body: Syntax error');
-        $request = new ServerRequest('POST', '/', [], 'notjson');
-        $mapper = new LegacyEventMapper();
-        $mapper->fromRequest($request);
-    }
-
     public function testWithContextProperty()
     {
         $mapper = new LegacyEventMapper();
-        $request = new ServerRequest('GET', '/', [], json_encode([
+        $jsonData = [
             'data' => 'foo',
             'context' => [
                 'eventId' => '1413058901901494',
@@ -50,8 +41,8 @@ class LegacyEventMapperTest extends TestCase
                     'service' => 'pubsub.googleapis.com'
                 ],
             ]
-        ]));
-        $cloudevent = $mapper->fromRequest($request);
+        ];
+        $cloudevent = $mapper->fromJsonData($jsonData);
 
         $this->assertEquals('1413058901901494', $cloudevent->getId());
         $this->assertEquals(
@@ -71,7 +62,7 @@ class LegacyEventMapperTest extends TestCase
     public function testWithoutContextProperty()
     {
         $mapper = new LegacyEventMapper();
-        $request = new ServerRequest('GET', '/', [], json_encode([
+        $jsonData = [
             'data' => 'foo',
             'eventId' => '1413058901901494',
             'timestamp' => '2020-12-08T20:03:19.162Z',
@@ -80,8 +71,8 @@ class LegacyEventMapperTest extends TestCase
                 'name' => 'projects/MY-PROJECT/topics/MY-TOPIC',
                 'service' => 'pubsub.googleapis.com'
             ],
-        ]));
-        $cloudevent = $mapper->fromRequest($request);
+        ];
+        $cloudevent = $mapper->fromJsonData($jsonData);
 
         $this->assertEquals('1413058901901494', $cloudevent->getId());
         $this->assertEquals(
@@ -102,14 +93,14 @@ class LegacyEventMapperTest extends TestCase
     public function testResourceAsString()
     {
         $mapper = new LegacyEventMapper();
-        $request = new ServerRequest('GET', '/', [], json_encode([
+        $jsonData = [
             'data' => 'foo',
             'eventId' => '1413058901901494',
             'timestamp' => '2020-12-08T20:03:19.162Z',
             'eventType' => 'providers/cloud.pubsub/eventTypes/topic.publish',
             'resource' => 'projects/MY-PROJECT/topics/MY-TOPIC',
-        ]));
-        $cloudevent = $mapper->fromRequest($request);
+        ];
+        $cloudevent = $mapper->fromJsonData($jsonData);
 
         $this->assertEquals('1413058901901494', $cloudevent->getId());
         $this->assertEquals(
@@ -130,7 +121,7 @@ class LegacyEventMapperTest extends TestCase
     public function testCloudStorage()
     {
         $mapper = new LegacyEventMapper();
-        $request = new ServerRequest('GET', '/', [], json_encode([
+        $jsonData = [
             'data' => 'foo',
             'context' => [
                 'eventId' => '1413058901901494',
@@ -141,8 +132,8 @@ class LegacyEventMapperTest extends TestCase
                     'service' => 'storage.googleapis.com'
                 ],
             ]
-        ]));
-        $cloudevent = $mapper->fromRequest($request);
+        ];
+        $cloudevent = $mapper->fromJsonData($jsonData);
 
         $this->assertEquals('1413058901901494', $cloudevent->getId());
         $this->assertEquals(

--- a/tests/LegacyEventMapperTest.php
+++ b/tests/LegacyEventMapperTest.php
@@ -20,7 +20,6 @@ namespace Google\CloudFunctions\Tests;
 
 use Google\CloudFunctions\LegacyEventMapper;
 use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Psr7\ServerRequest;
 
 /**
  * @group gcf-framework


### PR DESCRIPTION
See #60

The invoker catches all throwables of type `Exception` (**note**: `Error` types are not handled).
The invoker then sets:

  - the response status code to `200`
  - the `X-Google-Status` response header to "error" (cloudevent) or "crash" (http)
  - the response body to the error message

The invoker logs an error to `stderr` with a json-formatted stack trace.

Other notes: 
  - The end user cannot set status codes for Cloud Events
  - Invalid responses from http functions now result in a `LogicException`