### PR TITLE
Fix datacontenttype handling in binary mode events

### DIFF
--- a/tests/CloudEventFunctionsWrapperTest.php
+++ b/tests/CloudEventFunctionsWrapperTest.php
@@ -194,10 +194,10 @@ class CloudEventFunctionWrapperTest extends TestCase
             'ce-source' => '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
             'ce-specversion' => '1.0',
             'ce-type' => 'com.google.cloud.pubsub.topic.publish',
-            'ce-datacontenttype' => 'application/json',
             'ce-dataschema' => 'type.googleapis.com/google.logging.v2.LogEntry',
             'ce-subject' => 'My Subject',
             'ce-time' => '2020-12-08T20:03:19.162Z',
+            'Content-Type' => 'application/json',
         ], json_encode([
             "message" => [
                 "data" => "SGVsbG8gdGhlcmU=",
@@ -219,10 +219,10 @@ class CloudEventFunctionWrapperTest extends TestCase
             'ce-source' => '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
             'ce-specversion' => '1.0',
             'ce-type' => 'com.google.cloud.pubsub.topic.publish',
-            'ce-datacontenttype' => 'application/json',
             'ce-dataschema' => 'type.googleapis.com/google.logging.v2.LogEntry',
             'ce-subject' => 'My Subject',
             'ce-time' => '2020-12-08T20:03:19.162Z',
+            'Content-Type' => 'application/json',
         ], '123');
         $cloudEventFunctionWrapper->execute($request);
         $this->assertTrue(self::$functionCalled);


### PR DESCRIPTION
The spec says [1]:

  For the binary mode, the HTTP Content-Type header value corresponds to
  (MUST be populated from or written to) the CloudEvents datacontenttype
  attribute. Note that a ce-datacontenttype HTTP header MUST NOT also be
  present in the message.

We were depending on a ce-datacontenttype header. Populate
datacontenttype from Content-Type instead.

[1] https://github.com/cloudevents/spec/blob/v1.0.1/http-protocol-binding.md#311-http-content-type