### PR TITLE
feat: register GCS stream wrapper in router.php when the package exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,31 @@ with the request and response objects.
 
 [psr7]: https://www.php-fig.org/psr/psr-7/
 
+## Use Google Cloud Storage
+
+When you require the `google/cloud-storage` package with composer, the functions
+framework will register the `gs://` stream wrapper. This enables your function
+to read and write to Google Cloud Storage as you would any filesystem:
+
+```php
+// Get the contents of an object in GCS
+$object = file_get_contents('gs://{YOUR_BUCKET_NAME}/object.txt');
+// Make modifications
+$object .= "\nadd a line";
+// Write the new contents back to GCS
+file_put_contents('gs://{YOUR_BUCKET_NAME}/object.txt', $object);
+```
+
+You can unregister this at any time by using
+[`stream_wrapper_unregister`][stream_wrapper_unregister]:
+
+```php
+// unregister the automatically registered one
+stream_wrapper_unregister('gs');
+```
+
+[stream_wrapper_unregister]: https://www.php.net/manual/en/function.stream-wrapper-unregister.php
+
 ## Run your function on Knative
 
 Cloud Run and Cloud Run on GKE both implement the

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "psr/http-message": "^1.0"
   },
   "suggest": {
-    "google/cloud-storage": "Google Cloud Storage client library for storing and persisting files"
+    "google/cloud-storage": "Google Cloud Storage client library for storing and persisting objects. When included, the functions framework will register the gs:// stream wrapper."
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,9 @@
     "guzzlehttp/psr7": "^1.6",
     "psr/http-message": "^1.0"
   },
+  "suggest": {
+    "google/cloud-storage": "Google Cloud Storage client library for storing and persisting files"
+  },
   "autoload": {
     "psr-4": {
       "Google\\CloudFunctions\\": "src"

--- a/router.php
+++ b/router.php
@@ -36,16 +36,10 @@ if ($source = $projectContext->locateFunctionSource($functionSourceEnv)) {
     require_once $source;
 }
 
-if (class_exists(Google\Cloud\Storage\StreamWrapper::class)) {
-    // Register the "gs://" stream wrapper for Cloud Storage if the package
-    // "google/cloud-storage" is installed and the "gs" protocol has not been
-    // registered.
-    if (!in_array('gs', stream_get_wrappers())) {
-        // Create a default GCS client and register the stream wrapper
-        $storage = new Google\Cloud\Storage\StorageClient;
-        Google\Cloud\Storage\StreamWrapper::register($storage);
-    }
-}
+// Register the "gs://" stream wrapper for Cloud Storage if the package
+// "google/cloud-storage" is installed and the "gs" protocol has not been
+// registered
+$projectContext->registerCloudStorageStreamWrapperIfPossible();
 
 /**
  * Invoke the function based on the function type.

--- a/router.php
+++ b/router.php
@@ -38,9 +38,13 @@ if ($source = $projectContext->locateFunctionSource($functionSourceEnv)) {
 
 if (class_exists(Google\Cloud\Storage\StreamWrapper::class)) {
     // Register the "gs://" stream wrapper for Cloud Storage if the package
-    // "google/cloud-storage" is installed.
-    $storage = new Google\Cloud\Storage\StorageClient;
-    Google\Cloud\Storage\StreamWrapper::register($storage);
+    // "google/cloud-storage" is installed and the "gs" protocol has not been
+    // registered.
+    if (!in_array('gs', stream_get_wrappers())) {
+        // Create a default GCS client and register the stream wrapper
+        $storage = new Google\Cloud\Storage\StorageClient;
+        Google\Cloud\Storage\StreamWrapper::register($storage);
+    }
 }
 
 /**

--- a/router.php
+++ b/router.php
@@ -36,6 +36,13 @@ if ($source = $projectContext->locateFunctionSource($functionSourceEnv)) {
     require_once $source;
 }
 
+if (class_exists(Google\Cloud\Storage\StreamWrapper::class)) {
+    // Register the "gs://" stream wrapper for Cloud Storage if the package
+    // "google/cloud-storage" is installed.
+    $storage = new Google\Cloud\Storage\StorageClient;
+    Google\Cloud\Storage\StreamWrapper::register($storage);
+}
+
 /**
  * Invoke the function based on the function type.
  */

--- a/src/ProjectContext.php
+++ b/src/ProjectContext.php
@@ -77,12 +77,14 @@ class ProjectContext
         return null;
     }
 
+    /**
+     * Register the "gs://" stream wrapper for Cloud Storage if the package
+     * "google/cloud-storage" is installed and the "gs" protocol has not been
+     * registered.
+     */
     public function registerCloudStorageStreamWrapperIfPossible()
     {
         if (class_exists(StreamWrapper::class)) {
-            // Register the "gs://" stream wrapper for Cloud Storage if the package
-            // "google/cloud-storage" is installed and the "gs" protocol has not been
-            // registered.
             if (!in_array('gs', stream_get_wrappers())) {
                 // Create a default GCS client and register the stream wrapper
                 $storage = new StorageClient();

--- a/src/ProjectContext.php
+++ b/src/ProjectContext.php
@@ -17,6 +17,8 @@
 
 namespace Google\CloudFunctions;
 
+use Google\Cloud\Storage\StreamWrapper;
+use Google\Cloud\Storage\StorageClient;
 use RuntimeException;
 
 /**
@@ -73,5 +75,19 @@ class ProjectContext
 
         // No function source found. Assume the function source is autoloaded.
         return null;
+    }
+
+    public function registerCloudStorageStreamWrapperIfPossible()
+    {
+        if (class_exists(StreamWrapper::class)) {
+            // Register the "gs://" stream wrapper for Cloud Storage if the package
+            // "google/cloud-storage" is installed and the "gs" protocol has not been
+            // registered.
+            if (!in_array('gs', stream_get_wrappers())) {
+                // Create a default GCS client and register the stream wrapper
+                $storage = new StorageClient();
+                StreamWrapper::register($storage);
+            }
+        }
     }
 }

--- a/tests/ProjectContextTest.php
+++ b/tests/ProjectContextTest.php
@@ -18,6 +18,8 @@
 
 namespace Google\CloudFunctions\Tests;
 
+use Google\Cloud\Storage\StreamWrapper;
+use Google\Cloud\Storage\StorageClient;
 use Google\CloudFunctions\ProjectContext;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -78,5 +80,58 @@ class ProjectContextTest extends TestCase
 
         $context = new ProjectContext();
         $context->locateFunctionSource('nonexistant.php');
+    }
+
+    public function testGcsStreamWrapperNotRegisteredByDefault()
+    {
+        $context = new ProjectContext();
+        $defaultWrappers = stream_get_wrappers();
+
+        $context->registerCloudStorageStreamWrapperIfPossible();
+        $wrappers = stream_get_wrappers();
+
+        $this->assertSame($defaultWrappers, $wrappers);
+        $this->assertNotContains('gs', $wrappers);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGcsStreamWrapperRegisteredWhenClassExists()
+    {
+        $this->getMockBuilder(StorageClient::class)->getMock();
+        class_alias(StreamWrapperMock::class, StreamWrapper::class);
+
+        $context = new ProjectContext();
+        $defaultWrappers = stream_get_wrappers();
+
+        $context->registerCloudStorageStreamWrapperIfPossible();
+        $wrappers = stream_get_wrappers();
+
+        $this->assertNotContains('gs', $defaultWrappers);
+        $this->assertContains('gs', $wrappers);
+    }
+
+    public function testGcsStreamWrapperNotRegisteredWhenGsAlreadyRegistered()
+    {
+        $this->getMockBuilder(StorageClient::class)->getMock();
+
+        $context = new ProjectContext();
+        $defaultWrappers = stream_get_wrappers();
+
+        stream_wrapper_register('gs', __CLASS__);
+        // This would throw an error if it tried to register GCS because
+        // StreamWrapper does not exist
+        $context->registerCloudStorageStreamWrapperIfPossible();
+        $wrappers = stream_get_wrappers();
+
+        $this->assertNotContains('gs', $defaultWrappers);
+        $this->assertContains('gs', $wrappers);
+    }
+}
+
+class StreamWrapperMock {
+    static function register() {
+        stream_wrapper_register('gs', __CLASS__);
     }
 }

--- a/tests/ProjectContextTest.php
+++ b/tests/ProjectContextTest.php
@@ -112,6 +112,9 @@ class ProjectContextTest extends TestCase
         $this->assertContains('gs', $wrappers);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testGcsStreamWrapperNotRegisteredWhenGsAlreadyRegistered()
     {
         $this->getMockBuilder(StorageClient::class)->getMock();
@@ -130,8 +133,10 @@ class ProjectContextTest extends TestCase
     }
 }
 
-class StreamWrapperMock {
-    static function register() {
+class StreamWrapperMock
+{
+    public static function register()
+    {
         stream_wrapper_register('gs', __CLASS__);
     }
 }

--- a/tests/fixtures/gcs.php
+++ b/tests/fixtures/gcs.php
@@ -1,0 +1,13 @@
+<?php
+
+use Psr\Http\Message\ServerRequestInterface;
+
+function helloDefault(ServerRequestInterface $request)
+{
+    $wrappers = stream_get_wrappers();
+
+    return sprintf(
+        'GCS Stream Wrapper is %s',
+        in_array('gs', $wrappers) ? 'registered' : 'not registered'
+    );
+}

--- a/tests/routerTest.php
+++ b/tests/routerTest.php
@@ -62,6 +62,14 @@ class routerTest extends TestCase
 
         $this->expectOutputString('Invoked!');
     }
+
+    public function testCloudStorageStreamWrapperNotRegisteredByDefault()
+    {
+        $wrappers = stream_get_wrappers();
+        require 'router.php';
+        $this->assertEquals($wrappers, stream_get_wrappers());
+        $this->assertNotContains('gs', stream_get_wrappers());
+    }
 }
 
 function test_callable(ServerRequestInterface $request)

--- a/tests/vendorTest.php
+++ b/tests/vendorTest.php
@@ -67,7 +67,6 @@ class vendorTest extends TestCase
     public function testRelativeFunctionSource()
     {
         copy(__DIR__ . '/fixtures/relative.php', self::$tmpDir . '/relative.php');
-        putenv('FUNCTION_SOURCE=');
         $cmd = sprintf(
             'FUNCTION_SOURCE=relative.php' .
             ' FUNCTION_SIGNATURE_TYPE=http' .
@@ -83,7 +82,6 @@ class vendorTest extends TestCase
     public function testAbsoluteFunctionSource()
     {
         copy(__DIR__ . '/fixtures/absolute.php', self::$tmpDir . '/absolute.php');
-        putenv('FUNCTION_SOURCE=');
         $cmd = sprintf(
             'FUNCTION_SOURCE=%s/absolute.php' .
             ' FUNCTION_SIGNATURE_TYPE=http' .
@@ -100,7 +98,6 @@ class vendorTest extends TestCase
     public function testGcsIsNotRegistered()
     {
         copy(__DIR__ . '/fixtures/gcs.php', self::$tmpDir . '/gcs.php');
-        putenv('FUNCTION_SOURCE=');
         $cmd = sprintf(
             'FUNCTION_SOURCE=%s/gcs.php' .
             ' FUNCTION_SIGNATURE_TYPE=http' .
@@ -122,7 +119,6 @@ class vendorTest extends TestCase
         passthru('composer require google/cloud-storage');
 
         copy(__DIR__ . '/fixtures/gcs.php', self::$tmpDir . '/gcs.php');
-        putenv('FUNCTION_SOURCE=');
         $cmd = sprintf(
             'FUNCTION_SOURCE=%s/gcs.php' .
             ' FUNCTION_SIGNATURE_TYPE=http' .

--- a/tests/vendorTest.php
+++ b/tests/vendorTest.php
@@ -35,7 +35,8 @@ class vendorTest extends TestCase
             self::markTestSkipped('Explicitly skipping the example tests');
         }
 
-        mkdir($tmpDir = sys_get_temp_dir() . '/ff-php-test-' . rand());
+        $tmpDir = sprintf('%s/ff-php-test-%s', sys_get_temp_dir(), rand());
+        mkdir($tmpDir);
         chdir($tmpDir);
         echo "Running tests in $tmpDir\n";
 


### PR DESCRIPTION
implements #67

 - adds "suggest" entry in `composer.json` for `google/cloud-storage`
 - in `router.php` checks if `Google\Cloud\Storage\StreamWrapper` exists
 - if it exists, registers it with a default `Google\Cloud\Storage\StorageClient` instance
 - adds tests

**NOTE**: Consider refactoring `router.php` into a `Router` class, which gets called from `router.php`. The logic is becoming big enough to justify this