### PR TITLE
Fix assertions and use proper assertions

### DIFF
--- a/tests/CloudEventFunctionsWrapperTest.php
+++ b/tests/CloudEventFunctionsWrapperTest.php
@@ -41,12 +41,12 @@ class CloudEventFunctionWrapperTest extends TestCase
         $request = new ServerRequest('POST', '/', $headers, 'notjson');
         $cloudEventFunctionWrapper = new CloudEventFunctionWrapper([$this, 'invokeThis']);
         $response = $cloudEventFunctionWrapper->execute($request);
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEquals(
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(
             'Could not parse CloudEvent: Syntax error',
             (string) $response->getBody()
         );
-        $this->assertEquals('crash', $response->getHeaderLine('X-Google-Status'));
+        $this->assertSame('crash', $response->getHeaderLine('X-Google-Status'));
     }
 
     public function testInvalidLegacyEventRequestBody()
@@ -54,12 +54,12 @@ class CloudEventFunctionWrapperTest extends TestCase
         $request = new ServerRequest('POST', '/', [], 'notjson');
         $cloudEventFunctionWrapper = new CloudEventFunctionWrapper([$this, 'invokeThis']);
         $response = $cloudEventFunctionWrapper->execute($request);
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEquals(
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(
             'Could not parse CloudEvent: Syntax error',
             (string) $response->getBody()
         );
-        $this->assertEquals('crash', $response->getHeaderLine('X-Google-Status'));
+        $this->assertSame('crash', $response->getHeaderLine('X-Google-Status'));
     }
 
     public function testNonJsonIsValidInBinaryCloudEventRequestBody()
@@ -74,7 +74,7 @@ class CloudEventFunctionWrapperTest extends TestCase
             [$this, 'invokeThisPartial']
         );
         $response = $cloudEventFunctionWrapper->execute($request);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testInvalidJsonBinaryCloudEventRequestBody()
@@ -90,12 +90,12 @@ class CloudEventFunctionWrapperTest extends TestCase
             [$this, 'invokeThisPartial']
         );
         $response = $cloudEventFunctionWrapper->execute($request);
-        $this->assertEquals(400, $response->getStatusCode());
-        $this->assertEquals(
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame(
             'Could not parse CloudEvent: Syntax error',
             (string) $response->getBody()
         );
-        $this->assertEquals('crash', $response->getHeaderLine('X-Google-Status'));
+        $this->assertSame('crash', $response->getHeaderLine('X-Google-Status'));
     }
 
     public function testValidJsonBinaryCloudEventRequestBody()
@@ -111,7 +111,7 @@ class CloudEventFunctionWrapperTest extends TestCase
             [$this, 'invokeThisPartial']
         );
         $response = $cloudEventFunctionWrapper->execute($request);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     public function testNoFunctionParameters()
@@ -232,14 +232,14 @@ class CloudEventFunctionWrapperTest extends TestCase
     {
         $this->assertFalse(self::$functionCalled);
         self::$functionCalled = true;
-        $this->assertEquals('1413058901901494', $cloudevent->getId());
-        $this->assertEquals('//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC', $cloudevent->getSource());
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals('com.google.cloud.pubsub.topic.publish', $cloudevent->getType());
-        $this->assertEquals('application/json', $cloudevent->getDataContentType());
-        $this->assertEquals('type.googleapis.com/google.logging.v2.LogEntry', $cloudevent->getDataSchema());
-        $this->assertEquals('My Subject', $cloudevent->getSubject());
-        $this->assertEquals('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('1413058901901494', $cloudevent->getId());
+        $this->assertSame('//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC', $cloudevent->getSource());
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame('com.google.cloud.pubsub.topic.publish', $cloudevent->getType());
+        $this->assertSame('application/json', $cloudevent->getDataContentType());
+        $this->assertSame('type.googleapis.com/google.logging.v2.LogEntry', $cloudevent->getDataSchema());
+        $this->assertSame('My Subject', $cloudevent->getSubject());
+        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
     }
 
     public function testWithNotFullButValidCloudEvent()
@@ -262,10 +262,10 @@ class CloudEventFunctionWrapperTest extends TestCase
     {
         $this->assertFalse(self::$functionCalled);
         self::$functionCalled = true;
-        $this->assertEquals('fooBar', $cloudevent->getId());
-        $this->assertEquals('my-source', $cloudevent->getSource());
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals('my.type', $cloudevent->getType());
+        $this->assertSame('fooBar', $cloudevent->getId());
+        $this->assertSame('my-source', $cloudevent->getSource());
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame('my.type', $cloudevent->getType());
     }
 
     public function testFromLegacyEventWithContextProperty()
@@ -293,20 +293,20 @@ class CloudEventFunctionWrapperTest extends TestCase
     {
         $this->assertFalse(self::$functionCalled);
         self::$functionCalled = true;
-        $this->assertEquals('1413058901901494', $cloudevent->getId());
-        $this->assertEquals(
+        $this->assertSame('1413058901901494', $cloudevent->getId());
+        $this->assertSame(
             '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
             $cloudevent->getSource()
         );
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals(
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame(
             'google.cloud.pubsub.topic.v1.messagePublished',
             $cloudevent->getType()
         );
-        $this->assertEquals('application/json', $cloudevent->getDataContentType());
-        $this->assertEquals(null, $cloudevent->getDataSchema());
-        $this->assertEquals(null, $cloudevent->getSubject());
-        $this->assertEquals('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('application/json', $cloudevent->getDataContentType());
+        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertSame(null, $cloudevent->getSubject());
+        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
     }
 
     public function testFromStructuredEventRequest()

--- a/tests/CloudEventFunctionsWrapperTest.php
+++ b/tests/CloudEventFunctionsWrapperTest.php
@@ -304,8 +304,8 @@ class CloudEventFunctionWrapperTest extends TestCase
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
-        $this->assertSame(null, $cloudevent->getDataSchema());
-        $this->assertSame(null, $cloudevent->getSubject());
+        $this->assertNull($cloudevent->getDataSchema());
+        $this->assertNull($cloudevent->getSubject());
         $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
     }
 

--- a/tests/CloudEventTest.php
+++ b/tests/CloudEventTest.php
@@ -66,6 +66,6 @@ class CloudEventTest extends TestCase
     }
 }';
 
-        $this->assertEquals(json_encode($event, JSON_PRETTY_PRINT), $want);
+        $this->assertSame(json_encode($event, JSON_PRETTY_PRINT), $want);
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -33,25 +33,25 @@ class ContextTest extends TestCase
             'eventType' => 'ghi',
             'resource' => ['name' => 'jkl', 'service' => 'mno'],
         ]);
-        $this->assertEquals('abc', $context->getEventId());
-        $this->assertEquals('def', $context->getTimestamp());
-        $this->assertEquals('ghi', $context->getEventType());
-        $this->assertEquals([
+        $this->assertSame('abc', $context->getEventId());
+        $this->assertSame('def', $context->getTimestamp());
+        $this->assertSame('ghi', $context->getEventType());
+        $this->assertSame([
             'name' => 'jkl',
             'service' => 'mno'
         ], $context->getResource());
-        $this->assertEquals('jkl', $context->getResourceName());
-        $this->assertEquals('mno', $context->getService());
+        $this->assertSame('jkl', $context->getResourceName());
+        $this->assertSame('mno', $context->getService());
     }
 
     public function testFromEmptyArray()
     {
         $context = Context::fromArray([]);
-        $this->assertEquals(null, $context->getEventId());
-        $this->assertEquals(null, $context->getTimestamp());
-        $this->assertEquals(null, $context->getEventType());
-        $this->assertEquals(null, $context->getResource());
-        $this->assertEquals(null, $context->getResourceName());
-        $this->assertEquals(null, $context->getService());
+        $this->assertSame(null, $context->getEventId());
+        $this->assertSame(null, $context->getTimestamp());
+        $this->assertSame(null, $context->getEventType());
+        $this->assertSame(null, $context->getResource());
+        $this->assertSame(null, $context->getResourceName());
+        $this->assertSame(null, $context->getService());
     }
 }

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -47,11 +47,11 @@ class ContextTest extends TestCase
     public function testFromEmptyArray()
     {
         $context = Context::fromArray([]);
-        $this->assertSame(null, $context->getEventId());
-        $this->assertSame(null, $context->getTimestamp());
-        $this->assertSame(null, $context->getEventType());
-        $this->assertSame(null, $context->getResource());
-        $this->assertSame(null, $context->getResourceName());
-        $this->assertSame(null, $context->getService());
+        $this->assertNull($context->getEventId());
+        $this->assertNull($context->getTimestamp());
+        $this->assertNull($context->getEventType());
+        $this->assertNull($context->getResource());
+        $this->assertNull($context->getResourceName());
+        $this->assertNull($context->getService());
     }
 }

--- a/tests/EmitterTest.php
+++ b/tests/EmitterTest.php
@@ -39,9 +39,9 @@ class EmitterTest extends TestCase
         $headers = xdebug_get_headers();
         $output = ob_get_clean();
 
-        $this->assertEquals('Foo', $output);
+        $this->assertSame('Foo', $output);
         $this->assertContains('Foo-Header:bar', $headers);
-        $this->assertEquals(200, http_response_code());
+        $this->assertSame(200, http_response_code());
     }
 
     public function testSingleHeader()
@@ -49,9 +49,9 @@ class EmitterTest extends TestCase
         $emitter = new TestEmitter();
         $emitter->emit(new Response(200, ['foo-header' => 'bar']));
 
-        $this->assertEquals('Foo-Header:bar', $emitter->headers[1][0]);
-        $this->assertEquals(true, $emitter->headers[1][1]);
-        $this->assertEquals(200, $emitter->headers[1][2]);
+        $this->assertSame('Foo-Header:bar', $emitter->headers[1][0]);
+        $this->assertSame(true, $emitter->headers[1][1]);
+        $this->assertSame(200, $emitter->headers[1][2]);
     }
 
     public function testRepeatHeaders()
@@ -59,13 +59,13 @@ class EmitterTest extends TestCase
         $emitter = new TestEmitter();
         $emitter->emit(new Response(200, ['foo-header' => ['bar', 'baz']]));
 
-        $this->assertEquals('Foo-Header:bar', $emitter->headers[1][0]);
-        $this->assertEquals(true, $emitter->headers[1][1]);
-        $this->assertEquals(200, $emitter->headers[1][2]);
+        $this->assertSame('Foo-Header:bar', $emitter->headers[1][0]);
+        $this->assertSame(true, $emitter->headers[1][1]);
+        $this->assertSame(200, $emitter->headers[1][2]);
 
-        $this->assertEquals('Foo-Header:baz', $emitter->headers[2][0]);
-        $this->assertEquals(false, $emitter->headers[2][1]);
-        $this->assertEquals(200, $emitter->headers[2][2]);
+        $this->assertSame('Foo-Header:baz', $emitter->headers[2][0]);
+        $this->assertSame(false, $emitter->headers[2][1]);
+        $this->assertSame(200, $emitter->headers[2][2]);
     }
 
     public function testCookies()
@@ -73,13 +73,13 @@ class EmitterTest extends TestCase
         $emitter = new TestEmitter();
         $emitter->emit(new Response(200, ['Set-Cookie' => ['1', '2']]));
 
-        $this->assertEquals('Set-Cookie:1', $emitter->headers[1][0]);
-        $this->assertEquals(false, $emitter->headers[1][1]);
-        $this->assertEquals(200, $emitter->headers[1][2]);
+        $this->assertSame('Set-Cookie:1', $emitter->headers[1][0]);
+        $this->assertSame(false, $emitter->headers[1][1]);
+        $this->assertSame(200, $emitter->headers[1][2]);
 
-        $this->assertEquals('Set-Cookie:2', $emitter->headers[2][0]);
-        $this->assertEquals(false, $emitter->headers[2][1]);
-        $this->assertEquals(200, $emitter->headers[2][2]);
+        $this->assertSame('Set-Cookie:2', $emitter->headers[2][0]);
+        $this->assertSame(false, $emitter->headers[2][1]);
+        $this->assertSame(200, $emitter->headers[2][2]);
     }
 
     public function testStatusLine()
@@ -87,9 +87,9 @@ class EmitterTest extends TestCase
         $emitter = new TestEmitter();
         $emitter->emit(new Response(200));
 
-        $this->assertEquals('HTTP/1.1 200 OK', $emitter->headers[0][0]);
-        $this->assertEquals(true, $emitter->headers[0][1]);
-        $this->assertEquals(200, $emitter->headers[0][2]);
+        $this->assertSame('HTTP/1.1 200 OK', $emitter->headers[0][0]);
+        $this->assertSame(true, $emitter->headers[0][1]);
+        $this->assertSame(200, $emitter->headers[0][2]);
     }
 
     public function testStatusLineEmptyReasonPhrase()
@@ -97,9 +97,9 @@ class EmitterTest extends TestCase
         $emitter = new TestEmitter();
         $emitter->emit(new Response(419));
 
-        $this->assertEquals('HTTP/1.1 419', $emitter->headers[0][0]);
-        $this->assertEquals(true, $emitter->headers[0][1]);
-        $this->assertEquals(419, $emitter->headers[0][2]);
+        $this->assertSame('HTTP/1.1 419', $emitter->headers[0][0]);
+        $this->assertSame(true, $emitter->headers[0][1]);
+        $this->assertSame(419, $emitter->headers[0][2]);
     }
 }
 

--- a/tests/EmitterTest.php
+++ b/tests/EmitterTest.php
@@ -50,7 +50,7 @@ class EmitterTest extends TestCase
         $emitter->emit(new Response(200, ['foo-header' => 'bar']));
 
         $this->assertSame('Foo-Header:bar', $emitter->headers[1][0]);
-        $this->assertSame(true, $emitter->headers[1][1]);
+        $this->assertTrue($emitter->headers[1][1]);
         $this->assertSame(200, $emitter->headers[1][2]);
     }
 
@@ -60,11 +60,11 @@ class EmitterTest extends TestCase
         $emitter->emit(new Response(200, ['foo-header' => ['bar', 'baz']]));
 
         $this->assertSame('Foo-Header:bar', $emitter->headers[1][0]);
-        $this->assertSame(true, $emitter->headers[1][1]);
+        $this->assertTrue($emitter->headers[1][1]);
         $this->assertSame(200, $emitter->headers[1][2]);
 
         $this->assertSame('Foo-Header:baz', $emitter->headers[2][0]);
-        $this->assertSame(false, $emitter->headers[2][1]);
+        $this->assertFalse($emitter->headers[2][1]);
         $this->assertSame(200, $emitter->headers[2][2]);
     }
 
@@ -74,11 +74,11 @@ class EmitterTest extends TestCase
         $emitter->emit(new Response(200, ['Set-Cookie' => ['1', '2']]));
 
         $this->assertSame('Set-Cookie:1', $emitter->headers[1][0]);
-        $this->assertSame(false, $emitter->headers[1][1]);
+        $this->assertFalse($emitter->headers[1][1]);
         $this->assertSame(200, $emitter->headers[1][2]);
 
         $this->assertSame('Set-Cookie:2', $emitter->headers[2][0]);
-        $this->assertSame(false, $emitter->headers[2][1]);
+        $this->assertFalse($emitter->headers[2][1]);
         $this->assertSame(200, $emitter->headers[2][2]);
     }
 
@@ -88,7 +88,7 @@ class EmitterTest extends TestCase
         $emitter->emit(new Response(200));
 
         $this->assertSame('HTTP/1.1 200 OK', $emitter->headers[0][0]);
-        $this->assertSame(true, $emitter->headers[0][1]);
+        $this->assertTrue($emitter->headers[0][1]);
         $this->assertSame(200, $emitter->headers[0][2]);
     }
 
@@ -98,7 +98,7 @@ class EmitterTest extends TestCase
         $emitter->emit(new Response(419));
 
         $this->assertSame('HTTP/1.1 419', $emitter->headers[0][0]);
-        $this->assertSame(true, $emitter->headers[0][1]);
+        $this->assertTrue($emitter->headers[0][1]);
         $this->assertSame(419, $emitter->headers[0][2]);
     }
 }

--- a/tests/HttpFunctionWrapperTest.php
+++ b/tests/HttpFunctionWrapperTest.php
@@ -112,11 +112,11 @@ class HttpFunctionWrapperTest extends TestCase
         $request = new ServerRequest('GET', '/robots.txt');
         $response = $httpFunctionWrapper->execute($request);
         $this->assertSame(404, $response->getStatusCode());
-        $this->assertSame('', (string) $response->getBody());
+        $this->assertEmpty((string) $response->getBody());
         $request = new ServerRequest('GET', '/favicon.ico');
         $response = $httpFunctionWrapper->execute($request);
         $this->assertSame(404, $response->getStatusCode());
-        $this->assertSame('', (string) $response->getBody());
+        $this->assertEmpty((string) $response->getBody());
     }
 
     public function invokeThis(ServerRequestInterface $request)

--- a/tests/HttpFunctionWrapperTest.php
+++ b/tests/HttpFunctionWrapperTest.php
@@ -103,7 +103,7 @@ class HttpFunctionWrapperTest extends TestCase
         $httpFunctionWrapper = new HttpFunctionWrapper([$this, 'invokeThis']);
         $request = new ServerRequest('GET', '/');
         $response = $httpFunctionWrapper->execute($request);
-        $this->assertEquals('Invoked!', (string) $response->getBody());
+        $this->assertSame('Invoked!', (string) $response->getBody());
     }
 
     public function testHttpErrorPaths()
@@ -111,12 +111,12 @@ class HttpFunctionWrapperTest extends TestCase
         $httpFunctionWrapper = new HttpFunctionWrapper([$this, 'invokeThis']);
         $request = new ServerRequest('GET', '/robots.txt');
         $response = $httpFunctionWrapper->execute($request);
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEquals('', (string) $response->getBody());
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('', (string) $response->getBody());
         $request = new ServerRequest('GET', '/favicon.ico');
         $response = $httpFunctionWrapper->execute($request);
-        $this->assertEquals(404, $response->getStatusCode());
-        $this->assertEquals('', (string) $response->getBody());
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('', (string) $response->getBody());
     }
 
     public function invokeThis(ServerRequestInterface $request)

--- a/tests/HttpFunctionWrapperTest.php
+++ b/tests/HttpFunctionWrapperTest.php
@@ -103,7 +103,7 @@ class HttpFunctionWrapperTest extends TestCase
         $httpFunctionWrapper = new HttpFunctionWrapper([$this, 'invokeThis']);
         $request = new ServerRequest('GET', '/');
         $response = $httpFunctionWrapper->execute($request);
-        $this->assertEquals((string) $response->getBody(), 'Invoked!');
+        $this->assertEquals('Invoked!', (string) $response->getBody());
     }
 
     public function testHttpErrorPaths()
@@ -111,11 +111,11 @@ class HttpFunctionWrapperTest extends TestCase
         $httpFunctionWrapper = new HttpFunctionWrapper([$this, 'invokeThis']);
         $request = new ServerRequest('GET', '/robots.txt');
         $response = $httpFunctionWrapper->execute($request);
-        $this->assertEquals($response->getStatusCode(), 404);
+        $this->assertEquals(404, $response->getStatusCode());
         $this->assertEquals('', (string) $response->getBody());
         $request = new ServerRequest('GET', '/favicon.ico');
         $response = $httpFunctionWrapper->execute($request);
-        $this->assertEquals($response->getStatusCode(), 404);
+        $this->assertEquals(404, $response->getStatusCode());
         $this->assertEquals('', (string) $response->getBody());
     }
 

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -65,7 +65,7 @@ class InvokerTest extends TestCase
         $response = $invoker->handle($request);
 
         // Verify the error message response
-        $this->assertSame('', (string) $response->getBody());
+        $this->assertEmpty((string) $response->getBody());
         $this->assertSame(500, $response->getStatusCode());
         $this->assertTrue(
             $response->hasHeader(FunctionWrapper::FUNCTION_STATUS_HEADER)

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -41,7 +41,7 @@ class InvokerTest extends TestCase
     {
         $invoker = new Invoker([$this, 'invokeThis'], 'http');
         $response = $invoker->handle();
-        $this->assertEquals('Invoked!', (string) $response->getBody());
+        $this->assertSame('Invoked!', (string) $response->getBody());
     }
 
     /**
@@ -65,12 +65,12 @@ class InvokerTest extends TestCase
         $response = $invoker->handle($request);
 
         // Verify the error message response
-        $this->assertEquals('', (string) $response->getBody());
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertSame('', (string) $response->getBody());
+        $this->assertSame(500, $response->getStatusCode());
         $this->assertTrue(
             $response->hasHeader(FunctionWrapper::FUNCTION_STATUS_HEADER)
         );
-        $this->assertEquals(
+        $this->assertSame(
             $errorStatus,
             $response->getHeaderLine(FunctionWrapper::FUNCTION_STATUS_HEADER)
         );

--- a/tests/InvokerTest.php
+++ b/tests/InvokerTest.php
@@ -41,7 +41,7 @@ class InvokerTest extends TestCase
     {
         $invoker = new Invoker([$this, 'invokeThis'], 'http');
         $response = $invoker->handle();
-        $this->assertEquals((string) $response->getBody(), 'Invoked!');
+        $this->assertEquals('Invoked!', (string) $response->getBody());
     }
 
     /**

--- a/tests/LegacyEventMapperTest.php
+++ b/tests/LegacyEventMapperTest.php
@@ -54,8 +54,8 @@ class LegacyEventMapperTest extends TestCase
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
-        $this->assertSame(null, $cloudevent->getDataSchema());
-        $this->assertSame(null, $cloudevent->getSubject());
+        $this->assertNull($cloudevent->getDataSchema());
+        $this->assertNull($cloudevent->getSubject());
 
         // Verify Pub/Sub-specific data transformation.
         $this->assertSame(['message' => 'foo'], $cloudevent->getData());
@@ -87,8 +87,8 @@ class LegacyEventMapperTest extends TestCase
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
-        $this->assertSame(null, $cloudevent->getDataSchema());
-        $this->assertSame(null, $cloudevent->getSubject());
+        $this->assertNull($cloudevent->getDataSchema());
+        $this->assertNull($cloudevent->getSubject());
         $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
 
         // Verify Pub/Sub-specific data transformation.
@@ -118,8 +118,8 @@ class LegacyEventMapperTest extends TestCase
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
-        $this->assertSame(null, $cloudevent->getDataSchema());
-        $this->assertSame(null, $cloudevent->getSubject());
+        $this->assertNull($cloudevent->getDataSchema());
+        $this->assertNull($cloudevent->getSubject());
         $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
 
         // Verify Pub/Sub-specific data transformation.
@@ -154,7 +154,7 @@ class LegacyEventMapperTest extends TestCase
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
-        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertNull($cloudevent->getDataSchema());
         $this->assertSame(
             'objects/MyFile#1588778055917163',
             $cloudevent->getSubject()
@@ -201,7 +201,7 @@ class LegacyEventMapperTest extends TestCase
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
-        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertNull($cloudevent->getDataSchema());
         $this->assertSame(
             'users/UUpby3s4spZre6kHsgVSPetzQ8l2',
             $cloudevent->getSubject()

--- a/tests/LegacyEventMapperTest.php
+++ b/tests/LegacyEventMapperTest.php
@@ -43,22 +43,22 @@ class LegacyEventMapperTest extends TestCase
         ];
         $cloudevent = $mapper->fromJsonData($jsonData);
 
-        $this->assertEquals('1413058901901494', $cloudevent->getId());
-        $this->assertEquals(
+        $this->assertSame('1413058901901494', $cloudevent->getId());
+        $this->assertSame(
             '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
             $cloudevent->getSource()
         );
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals(
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame(
             'google.cloud.pubsub.topic.v1.messagePublished',
             $cloudevent->getType()
         );
-        $this->assertEquals('application/json', $cloudevent->getDataContentType());
-        $this->assertEquals(null, $cloudevent->getDataSchema());
-        $this->assertEquals(null, $cloudevent->getSubject());
+        $this->assertSame('application/json', $cloudevent->getDataContentType());
+        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertSame(null, $cloudevent->getSubject());
 
         // Verify Pub/Sub-specific data transformation.
-        $this->assertEquals(['message' => 'foo'], $cloudevent->getData());
+        $this->assertSame(['message' => 'foo'], $cloudevent->getData());
     }
 
     public function testWithoutContextProperty()
@@ -76,23 +76,23 @@ class LegacyEventMapperTest extends TestCase
         ];
         $cloudevent = $mapper->fromJsonData($jsonData);
 
-        $this->assertEquals('1413058901901494', $cloudevent->getId());
-        $this->assertEquals(
+        $this->assertSame('1413058901901494', $cloudevent->getId());
+        $this->assertSame(
             '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
             $cloudevent->getSource()
         );
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals(
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame(
             'google.cloud.pubsub.topic.v1.messagePublished',
             $cloudevent->getType()
         );
-        $this->assertEquals('application/json', $cloudevent->getDataContentType());
-        $this->assertEquals(null, $cloudevent->getDataSchema());
-        $this->assertEquals(null, $cloudevent->getSubject());
-        $this->assertEquals('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('application/json', $cloudevent->getDataContentType());
+        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertSame(null, $cloudevent->getSubject());
+        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
 
         // Verify Pub/Sub-specific data transformation.
-        $this->assertEquals(['message' => 'foo'], $cloudevent->getData());
+        $this->assertSame(['message' => 'foo'], $cloudevent->getData());
     }
 
     public function testResourceAsString()
@@ -107,23 +107,23 @@ class LegacyEventMapperTest extends TestCase
         ];
         $cloudevent = $mapper->fromJsonData($jsonData);
 
-        $this->assertEquals('1413058901901494', $cloudevent->getId());
-        $this->assertEquals(
+        $this->assertSame('1413058901901494', $cloudevent->getId());
+        $this->assertSame(
             '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
             $cloudevent->getSource()
         );
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals(
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame(
             'google.cloud.pubsub.topic.v1.messagePublished',
             $cloudevent->getType()
         );
-        $this->assertEquals('application/json', $cloudevent->getDataContentType());
-        $this->assertEquals(null, $cloudevent->getDataSchema());
-        $this->assertEquals(null, $cloudevent->getSubject());
-        $this->assertEquals('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('application/json', $cloudevent->getDataContentType());
+        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertSame(null, $cloudevent->getSubject());
+        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
 
         // Verify Pub/Sub-specific data transformation.
-        $this->assertEquals(['message' => 'foo'], $cloudevent->getData());
+        $this->assertSame(['message' => 'foo'], $cloudevent->getData());
     }
 
     public function testCloudStorage()
@@ -143,24 +143,24 @@ class LegacyEventMapperTest extends TestCase
         ];
         $cloudevent = $mapper->fromJsonData($jsonData);
 
-        $this->assertEquals('1413058901901494', $cloudevent->getId());
-        $this->assertEquals(
+        $this->assertSame('1413058901901494', $cloudevent->getId());
+        $this->assertSame(
             '//storage.googleapis.com/projects/_/buckets/sample-bucket',
             $cloudevent->getSource()
         );
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals(
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame(
             'google.cloud.storage.object.v1.finalized',
             $cloudevent->getType()
         );
-        $this->assertEquals('application/json', $cloudevent->getDataContentType());
-        $this->assertEquals(null, $cloudevent->getDataSchema());
-        $this->assertEquals(
+        $this->assertSame('application/json', $cloudevent->getDataContentType());
+        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertSame(
             'objects/MyFile#1588778055917163',
             $cloudevent->getSubject()
         );
-        $this->assertEquals('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
-        $this->assertEquals('foo', $cloudevent->getData());
+        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('foo', $cloudevent->getData());
     }
 
     public function testFirebaseAuth()
@@ -190,24 +190,24 @@ class LegacyEventMapperTest extends TestCase
         ];
         $cloudevent = $mapper->fromJsonData($jsonData);
 
-        $this->assertEquals('aaaaaa-1111-bbbb-2222-cccccccccccc', $cloudevent->getId());
-        $this->assertEquals(
+        $this->assertSame('aaaaaa-1111-bbbb-2222-cccccccccccc', $cloudevent->getId());
+        $this->assertSame(
             '//firebaseauth.googleapis.com/projects/my-project-id',
             $cloudevent->getSource()
         );
-        $this->assertEquals('1.0', $cloudevent->getSpecVersion());
-        $this->assertEquals(
+        $this->assertSame('1.0', $cloudevent->getSpecVersion());
+        $this->assertSame(
             'google.firebase.auth.user.v1.created',
             $cloudevent->getType()
         );
-        $this->assertEquals('application/json', $cloudevent->getDataContentType());
-        $this->assertEquals(null, $cloudevent->getDataSchema());
-        $this->assertEquals(
+        $this->assertSame('application/json', $cloudevent->getDataContentType());
+        $this->assertSame(null, $cloudevent->getDataSchema());
+        $this->assertSame(
             'users/UUpby3s4spZre6kHsgVSPetzQ8l2',
             $cloudevent->getSubject()
         );
-        $this->assertEquals('2020-09-29T11:32:00.000Z', $cloudevent->getTime());
-        $this->assertEquals('2020-05-26T10:42:27Z', $cloudevent->getData()['metadata']['createTime']);
-        $this->assertEquals('2020-10-24T11:00:00Z', $cloudevent->getData()['metadata']['lastSignInTime']);
+        $this->assertSame('2020-09-29T11:32:00.000Z', $cloudevent->getTime());
+        $this->assertSame('2020-05-26T10:42:27Z', $cloudevent->getData()['metadata']['createTime']);
+        $this->assertSame('2020-10-24T11:00:00Z', $cloudevent->getData()['metadata']['lastSignInTime']);
     }
 }

--- a/tests/dockerTest.php
+++ b/tests/dockerTest.php
@@ -72,8 +72,8 @@ class dockerTest extends TestCase
 
         $response = self::$client->get('/');
 
-        $this->assertEquals(418, $response->getStatusCode());
-        $this->assertEquals("I'm a teapot", $response->getReasonPhrase());
+        $this->assertSame(418, $response->getStatusCode());
+        $this->assertSame("I'm a teapot", $response->getReasonPhrase());
 
         passthru('docker rm -f ' . self::$containerId);
         self::$containerId = null;

--- a/tests/exampleTest.php
+++ b/tests/exampleTest.php
@@ -68,13 +68,13 @@ class exampleTest extends TestCase
         sleep(1);
 
         $response = self::$client->get('/');
-        $this->assertEquals(
+        $this->assertSame(
             'Hello World from PHP HTTP function!' . PHP_EOL,
             $response->getBody()->getContents()
         );
 
         $response = self::$client->get('/?name=Foo');
-        $this->assertEquals(
+        $this->assertSame(
             'Hello Foo from PHP HTTP function!' . PHP_EOL,
             $response->getBody()->getContents()
         );
@@ -107,8 +107,8 @@ class exampleTest extends TestCase
             'json' => ['foo' => 'bar']
         ]);
 
-        $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals('', $response->getBody()->getContents());
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('', $response->getBody()->getContents());
 
         exec('docker logs ' . self::$containerId, $output);
 

--- a/tests/exampleTest.php
+++ b/tests/exampleTest.php
@@ -108,7 +108,7 @@ class exampleTest extends TestCase
         ]);
 
         $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('', $response->getBody()->getContents());
+        $this->assertEmpty($response->getBody()->getContents());
 
         exec('docker logs ' . self::$containerId, $output);
 

--- a/tests/vendorTest.php
+++ b/tests/vendorTest.php
@@ -60,7 +60,7 @@ class vendorTest extends TestCase
         );
         exec($cmd, $output);
 
-        $this->assertEquals(['Hello Default!'], $output);
+        $this->assertSame(['Hello Default!'], $output);
     }
 
     public function testRelativeFunctionSource()
@@ -76,7 +76,7 @@ class vendorTest extends TestCase
         );
         exec($cmd, $output);
 
-        $this->assertEquals(['Hello Relative!'], $output);
+        $this->assertSame(['Hello Relative!'], $output);
     }
 
     public function testAbsoluteFunctionSource()
@@ -93,6 +93,6 @@ class vendorTest extends TestCase
         );
         exec($cmd, $output);
 
-        $this->assertEquals(['Hello Absolute!'], $output);
+        $this->assertSame(['Hello Absolute!'], $output);
     }
 }


### PR DESCRIPTION
Some assertions had their arguments inverted, this is fixed within: d7d79bcd0b0f185c19ad934b9efdc1f8a7fabb69

Also this PR makes sure that stricter assertions are always used and that, proper assertions (bool, null, empty) are used.