### PR TITLE
Enable PSR-4 for autoload-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Google\\CloudFunctions\\": "src"
+      "Google\\CloudFunctions\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Google\\CloudFunctions\\Tests\\": "tests/"
     }
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,6 @@
       "Google\\CloudFunctions\\": "src/"
     }
   },
-  "autoload-dev": {
-    "psr-4": {
-      "Google\\CloudFunctions\\Tests\\": "tests/"
-    }
-  },
   "require-dev": {
     "phpunit/phpunit": "^7.0|^8.0",
     "guzzlehttp/guzzle": "^7.2"

--- a/tests/CloudEventFunctionsWrapperTest.php
+++ b/tests/CloudEventFunctionsWrapperTest.php
@@ -26,7 +26,7 @@ use GuzzleHttp\Psr7\ServerRequest;
 /**
  * @group gcf-framework
  */
-class CloudEventFunctionWrapperTest extends TestCase
+class CloudEventFunctionsWrapperTest extends TestCase
 {
     private static $functionCalled;
 


### PR DESCRIPTION
Enable PSR-4 for `autoload-dev`

---

job https://github.com/GoogleCloudPlatform/functions-framework-php/pull/90/checks?check_run_id=2585735157 is fixed in https://github.com/GoogleCloudPlatform/functions-framework-php/pull/89