### PR TITLE
Disable coverage

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -27,6 +27,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-version }}
+        coverage: 'none'
 
     - name: Install Dependencies
       uses: nick-invision/retry@v1

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -19,6 +19,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
+        coverage: 'none'
     - name: Install Dependencies
       uses: nick-invision/retry@v1
       with:


### PR DESCRIPTION
By default will come with `xdebug` or `pcov` : https://github.com/shivammathur/setup-php#signal_strength-coverage-support

As we don't do any code coverage here, it is safe to disable coverage; this will also sensibly speed up the tests