### PR TITLE
fix: Firebase RTDB event types have ".ref" not ".document"

### DIFF
--- a/src/LegacyEventMapper.php
+++ b/src/LegacyEventMapper.php
@@ -38,10 +38,10 @@ class LegacyEventMapper
         'providers/firebase.auth/eventTypes/user.create' => 'google.firebase.auth.user.v1.created',
         'providers/firebase.auth/eventTypes/user.delete' => 'google.firebase.auth.user.v1.deleted',
         'providers/google.firebase.analytics/eventTypes/event.log' => 'google.firebase.analytics.log.v1.written',
-        'providers/google.firebase.database/eventTypes/ref.create' => 'google.firebase.database.document.v1.created',
-        'providers/google.firebase.database/eventTypes/ref.write' => 'google.firebase.database.document.v1.written',
-        'providers/google.firebase.database/eventTypes/ref.update' => 'google.firebase.database.document.v1.updated',
-        'providers/google.firebase.database/eventTypes/ref.delete' => 'google.firebase.database.document.v1.deleted',
+        'providers/google.firebase.database/eventTypes/ref.create' => 'google.firebase.database.ref.v1.created',
+        'providers/google.firebase.database/eventTypes/ref.write' => 'google.firebase.database.ref.v1.written',
+        'providers/google.firebase.database/eventTypes/ref.update' => 'google.firebase.database.ref.v1.updated',
+        'providers/google.firebase.database/eventTypes/ref.delete' => 'google.firebase.database.ref.v1.deleted',
         'providers/cloud.storage/eventTypes/object.change' => 'google.cloud.storage.object.v1.finalized',
     ];
 

--- a/tests/LegacyEventMapperTest.php
+++ b/tests/LegacyEventMapperTest.php
@@ -252,7 +252,7 @@ class LegacyEventMapperTest extends TestCase
         );
         $this->assertSame('1.0', $cloudevent->getSpecVersion());
         $this->assertSame(
-            'google.firebase.database.document.v1.deleted',
+            'google.firebase.database.ref.v1.deleted',
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
@@ -295,7 +295,7 @@ class LegacyEventMapperTest extends TestCase
         );
         $this->assertSame('1.0', $cloudevent->getSpecVersion());
         $this->assertSame(
-            'google.firebase.database.document.v1.deleted',
+            'google.firebase.database.ref.v1.deleted',
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());
@@ -338,7 +338,7 @@ class LegacyEventMapperTest extends TestCase
         );
         $this->assertSame('1.0', $cloudevent->getSpecVersion());
         $this->assertSame(
-            'google.firebase.database.document.v1.deleted',
+            'google.firebase.database.ref.v1.deleted',
             $cloudevent->getType()
         );
         $this->assertSame('application/json', $cloudevent->getDataContentType());


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/functions-framework-conformance/pull/79