### PR TITLE
refactor: add class that wraps CloudEvent into CloudEventInterface

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ '7.2', '7.3', '7.4','8.0' ]
+        php-version: [ '7.4','8.0' ]
     name: PHP ${{ matrix.php-version }} Conformance Test
     steps:
     - name: Checkout code

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: [ '7.2', '7.3', '7.4','8.0' ]
+        php-versions: [ '7.4','8.0' ]
     name: PHP ${{ matrix.php-versions }} Unit Test
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Google Cloud Functions Framework for PHP",
   "license": "Apache-2.0",
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "guzzlehttp/psr7": "^1.7|^2.0",
     "psr/http-message": "^1.0",
     "cloudevents/sdk-php": "^1.0"
@@ -17,7 +17,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0|^8.0",
+    "phpunit/phpunit": "^7.5|^8.0",
     "guzzlehttp/guzzle": "^7.2"
   },
   "bin": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "require": {
     "php": ">=7.2",
     "guzzlehttp/psr7": "^1.7|^2.0",
-    "psr/http-message": "^1.0"
+    "psr/http-message": "^1.0",
+    "cloudevents/sdk-php": "^1.0"
   },
   "suggest": {
     "google/cloud-storage": "Google Cloud Storage client library for storing and persisting objects. When included, the functions framework will register the gs:// stream wrapper."

--- a/src/CloudEventSdkCompliant.php
+++ b/src/CloudEventSdkCompliant.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\CloudFunctions;
+
+use BadMethodCallException;
+use JsonSerializable;
+use CloudEvents\V1\CloudEventInterface;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+/**
+ * @internal
+ * Wraps a Google\CloudFunctions\CloudEvent to comply with
+ * CloudEvents\V1\CloudEventInterface.
+ */
+class CloudEventSdkCompliant implements JsonSerializable, CloudEventInterface
+{
+    private $cloudevent;
+
+    public function __construct(
+        CloudEvent $cloudevent
+    ) {
+        $this->cloudevent = $cloudevent;
+    }
+
+    public function getId(): string
+    {
+        return $this->cloudevent->getId();
+    }
+    public function getSource(): string
+    {
+        return $this->cloudevent->getSource();
+    }
+    public function getSpecVersion(): string
+    {
+        return $this->cloudevent->getSpecVersion();
+    }
+    public function getType(): string
+    {
+        return $this->cloudevent->getType();
+    }
+    public function getDataContentType(): ?string
+    {
+        return $this->cloudevent->getDataContentType();
+    }
+    public function getDataSchema(): ?string
+    {
+        return $this->cloudevent->getDataSchema();
+    }
+    public function getSubject(): ?string
+    {
+        return $this->cloudevent->getSubject();
+    }
+    public function getTime(): ?DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->cloudevent->getTime());
+    }
+    public function getExtension(string $attribute)
+    {
+        throw new BadMethodCallException('getExtension() is not currently supported by Functions Framework PHP');
+    }
+    public function getExtensions(): array
+    {
+        throw new BadMethodCallException('getExtensions() is not currently supported by Functions Framework PHP');
+    }
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->cloudevent->getData();
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->cloudevent->jsonSerialize();
+    }
+
+    public function __toString()
+    {
+        return $this->cloudevent->__toString();
+    }
+}

--- a/tests/CloudEventSdkCompliantTest.php
+++ b/tests/CloudEventSdkCompliantTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Copyright 2021 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\CloudFunctions\Tests;
+
+use BadMethodCallException;
+use Google\CloudFunctions\CloudEvent;
+use Google\CloudFunctions\CloudEventSdkCompliant;
+use PHPUnit\Framework\TestCase;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+/**
+ * @group gcf-framework
+ * @group newtest
+ */
+class CloudEventSdkCompliantTest extends TestCase
+{
+    private CloudEvent $cloudevent;
+
+    function setUp(): void
+    {
+        $this->cloudevent = new CloudEvent(
+            '1413058901901494',
+            '//pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC',
+            '1.0',
+            'com.google.cloud.pubsub.topic.publish',
+            'application/json',
+            'type.googleapis.com/google.logging.v2.LogEntry',
+            'My Subject',
+            '2020-12-08T20:03:19.162Z',
+            [
+                "message" => [
+                    "data" => "SGVsbG8gdGhlcmU=",
+                    "messageId" => "1408577928008405",
+                    "publishTime" => "2020-08-06T22:31:14.536Z"
+                ],
+                "subscription" => "projects/MY-PROJECT/subscriptions/MY-SUB"
+            ]
+        );
+    }
+
+    public function testJsonSerialize(): void
+    {
+
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+
+        $want = '{
+    "id": "1413058901901494",
+    "source": "\/\/pubsub.googleapis.com\/projects\/MY-PROJECT\/topics\/MY-TOPIC",
+    "specversion": "1.0",
+    "type": "com.google.cloud.pubsub.topic.publish",
+    "datacontenttype": "application\/json",
+    "dataschema": "type.googleapis.com\/google.logging.v2.LogEntry",
+    "subject": "My Subject",
+    "time": "2020-12-08T20:03:19.162Z",
+    "data": {
+        "message": {
+            "data": "SGVsbG8gdGhlcmU=",
+            "messageId": "1408577928008405",
+            "publishTime": "2020-08-06T22:31:14.536Z"
+        },
+        "subscription": "projects\\/MY-PROJECT\\/subscriptions\\/MY-SUB"
+    }
+}';
+
+        $this->assertSame($want, json_encode($wrappedEvent, JSON_PRETTY_PRINT));
+    }
+
+    public function testWrapsCloudEvent(): void
+    {
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+
+        $this->assertSame($this->cloudevent->getId(), $wrappedEvent->getId());
+        $this->assertSame($this->cloudevent->getSource(), $wrappedEvent->getSource());
+        $this->assertSame($this->cloudevent->getType(), $wrappedEvent->getType());
+        $this->assertSame($this->cloudevent->getData(), $wrappedEvent->getData());
+        $this->assertSame($this->cloudevent->getDataContentType(), $wrappedEvent->getDataContentType());
+        $this->assertSame($this->cloudevent->getDataSchema(), $wrappedEvent->getDataSchema());
+        $this->assertSame($this->cloudevent->getSubject(), $wrappedEvent->getSubject());
+        $this->assertEquals(DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->cloudevent->getTime()), $wrappedEvent->getTime());
+    }
+
+    public function testUnimplementedGetExtensionThrowsError(): void
+    {
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+        $this->expectException(BadMethodCallException::class);
+
+        $wrappedEvent->getExtension('attribute');
+    }
+
+    public function testUnimplementedGetExtensionsThrowsError(): void
+    {
+        $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
+        $this->expectException(BadMethodCallException::class);
+
+        $wrappedEvent->getExtensions();
+    }
+}

--- a/tests/CloudEventSdkCompliantTest.php
+++ b/tests/CloudEventSdkCompliantTest.php
@@ -27,13 +27,12 @@ use DateTimeInterface;
 
 /**
  * @group gcf-framework
- * @group newtest
  */
 class CloudEventSdkCompliantTest extends TestCase
 {
     private CloudEvent $cloudevent;
 
-    function setUp(): void
+    public function setUp(): void
     {
         $this->cloudevent = new CloudEvent(
             '1413058901901494',
@@ -57,7 +56,6 @@ class CloudEventSdkCompliantTest extends TestCase
 
     public function testJsonSerialize(): void
     {
-
         $wrappedEvent = new CloudEventSdkCompliant($this->cloudevent);
 
         $want = '{


### PR DESCRIPTION
This is groundwork to enabling function signatures that expect the
official PHP CloudEvent SDKs [CloudEventInterface](https://github.com/cloudevents/sdk-php/blob/master/src/V1/CloudEventInterface.php)
instead of the Function Framework's hand-rolled class.

This also gives us an interface to support CloudEvent extensions properly #112 