### PR TITLE
Fix CloudEvents Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ cloudevent function signature:
 ```php
 use Google\CloudFunctions\CloudEvent;
 
-function helloCloudEvents(CloudEvent $cloudevent)
+function helloCloudEvent(CloudEvent $cloudevent)
 {
     // Print the whole CloudEvent
     $stdout = fopen('php://stdout', 'wb');


### PR DESCRIPTION
The exported `FUNCTION_TARGET` is `helloCloudEvent`. Therefore the function should also be named `helloCloudEvent`