### PR TITLE
chore: add GCF buildpack integration test Workflow 

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -1,0 +1,30 @@
+# Validates Functions Framework with GCF buildpacks.
+name: Buildpack Integration Test
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  php74:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.4.1
+    with:
+      http-builder-source: '/tests/conformance/index.php'
+      http-builder-target: 'declarativeHttpFunc'
+      cloudevent-builder-source: '/tests/conformance/index.php'
+      cloudevent-builder-target: 'declarativeCloudEventFunc'
+      prerun: 'test/conformance/prerun.sh'
+      builder-runtime: 'php74'
+      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/php74/builder
+      builder-tag: 'php74_20220531_7_4_29_RC00'
+  php81:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.4.1
+    with:
+      http-builder-source: '/tests/conformance/index.php'
+      http-builder-target: 'declarativeHttpFunc'
+      cloudevent-builder-source: '/tests/conformance/index.php'
+      cloudevent-builder-target: 'declarativeCloudEventFunc'
+      prerun: 'test/conformance/prerun.sh'
+      builder-runtime: 'php81'
+      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/php81/builder
+      builder-tag: 'php81_20220530_8_1_6_RC00'

--- a/tests/conformance/composer.json
+++ b/tests/conformance/composer.json
@@ -1,0 +1,15 @@
+{
+  "repositories": [
+      {
+          "type": "path",
+          "url": "./../..",
+          "options": {
+              "symlink": false
+          }
+      }
+  ],
+  "require": {
+      "google/cloud-functions-framework": "*"
+  },
+  "minimum-stability": "dev"
+}

--- a/tests/conformance/composer.json
+++ b/tests/conformance/composer.json
@@ -1,13 +1,4 @@
 {
-  "repositories": [
-      {
-          "type": "path",
-          "url": "./../..",
-          "options": {
-              "symlink": false
-          }
-      }
-  ],
   "require": {
       "google/cloud-functions-framework": "*"
   },

--- a/tests/conformance/prerun.sh
+++ b/tests/conformance/prerun.sh
@@ -1,0 +1,12 @@
+# prerun.sh sets up the test function to use the functions framework commit
+# specified by generating a `composer.json`. This makes the function `pack` buildable
+# with GCF buildpacks.
+#
+# `pack` command example:
+# pack build test-fast --builder us.gcr.io/fn-img/buildpacks/php74/builder:php74_20220531_7_4_29_RC00 --env GOOGLE_RUNTIME=php74 --env GOOGLE_FUNCTION_TARGET=declarativeHttpFunc
+set -e
+
+SCRIPT_DIR=$(realpath $(dirname $0))
+cd $SCRIPT_DIR
+
+composer install


### PR DESCRIPTION
Test. Adding buildpack integ test.

```
pack build test-fast --verbose \
--builder us.gcr.io/fn-img/buildpacks/php74/builder:php74_20220531_7_4_29_RC00 \
--env GOOGLE_RUNTIME=php74 \
--env GOOGLE_FUNCTION_TARGET=declarativeHttpFunc
```

Not sure about the prerun script.

- https://github.com/GoogleCloudPlatform/functions-framework-nodejs/pull/458
- https://github.com/GoogleCloudPlatform/functions-framework-python/pull/185