### PR TITLE
chore: add GCF buildpack integration test Workflow

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -1,0 +1,32 @@
+# Validates Functions Framework with GCF buildpacks.
+name: Buildpack Integration Test
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  php74-buildpack-test:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.5.4
+    with:
+      http-builder-source: 'tests/conformance'
+      http-builder-target: 'declarativeHttpFunc'
+      cloudevent-builder-source: 'tests/conformance'
+      cloudevent-builder-target: 'declarativeCloudEventFunc'
+      prerun: 'tests/conformance/prerun.sh ${{ github.sha }}'
+      output-file: 'vendor/bin/function_output.json'
+      builder-runtime: 'php74'
+      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/php74/builder
+      builder-tag: 'php74_20220620_7_4_29_RC00'
+  php81-buildpack-test:
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.5.4
+    with:
+      http-builder-source: 'tests/conformance'
+      http-builder-target: 'declarativeHttpFunc'
+      cloudevent-builder-source: 'tests/conformance'
+      cloudevent-builder-target: 'declarativeCloudEventFunc'
+      prerun: 'tests/conformance/prerun.sh ${{ github.sha }}'
+      output-file: 'vendor/bin/function_output.json'
+      builder-runtime: 'php81'
+      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/php81/builder
+      builder-tag: 'php81_20220620_8_1_6_RC00'

--- a/tests/conformance/prerun.sh
+++ b/tests/conformance/prerun.sh
@@ -1,0 +1,27 @@
+# prerun.sh sets up the test function to use the functions framework commit
+# specified by generating a `composer.json`. This makes the function `pack` buildable
+# with GCF buildpacks.
+#
+# `pack` build example command:
+# pack build myfn --builder us.gcr.io/fn-img/buildpacks/php74/builder:php74_20220620_7_4_29_RC00 --env GOOGLE_RUNTIME=php74 --env GOOGLE_FUNCTION_TARGET=declarativeHttpFunc --env X_GOOGLE_TARGET_PLATFORM=gcf
+FRAMEWORK_VERSION=$1
+
+# exit when any command fails
+set -e
+
+cd $(dirname $0)
+
+if [ -z "${FRAMEWORK_VERSION}" ]
+    then
+        echo "Functions Framework version required as first parameter"
+        exit 1
+fi
+
+echo '{
+    "require": {
+        "google/cloud-functions-framework": "dev-main#'${FRAMEWORK_VERSION}'",
+        "cloudevents/sdk-php": "^1.0"
+    }
+}' > composer.json
+
+cat composer.json

--- a/tests/conformance/run_conformance_tests.sh
+++ b/tests/conformance/run_conformance_tests.sh
@@ -14,6 +14,12 @@
 # Defaults to the latest version of the repo, which may be ahead of the
 # latest release.
 
+# exit when any command fails
+set -e
+
+# Change into the repo root
+cd $(dirname $0)/../..
+
 CLIENT_VERSION=$1
 if [ $CLIENT_VERSION ]; then
     CLIENT_VERSION="@$CLIENT_VERSION"


### PR DESCRIPTION
See [functions-framework-conformance builidpack integration workflow PR](https://github.com/GoogleCloudPlatform/functions-framework-conformance/pull/99) for more information.

Also, move the script for running conformance tests locally to the
conformance test directory.