### PR TITLE
chore: update buildpack integration test

### DIFF
--- a/.github/workflows/buildpack-integration-test.yml
+++ b/.github/workflows/buildpack-integration-test.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   php74-buildpack-test:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.5.4
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
     with:
       http-builder-source: 'tests/conformance'
       http-builder-target: 'declarativeHttpFunc'
@@ -16,10 +16,8 @@ jobs:
       prerun: 'tests/conformance/prerun.sh ${{ github.sha }}'
       output-file: 'vendor/bin/function_output.json'
       builder-runtime: 'php74'
-      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/php74/builder
-      builder-tag: 'php74_20220620_7_4_29_RC00'
   php81-buildpack-test:
-    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.5.4
+    uses: GoogleCloudPlatform/functions-framework-conformance/.github/workflows/buildpack-integration-test.yml@v1.8.0
     with:
       http-builder-source: 'tests/conformance'
       http-builder-target: 'declarativeHttpFunc'
@@ -28,5 +26,3 @@ jobs:
       prerun: 'tests/conformance/prerun.sh ${{ github.sha }}'
       output-file: 'vendor/bin/function_output.json'
       builder-runtime: 'php81'
-      # Latest uploaded tag from us.gcr.io/fn-img/buildpacks/php81/builder
-      builder-tag: 'php81_20220620_8_1_6_RC00'


### PR DESCRIPTION
Newest version of the client does not require a builder-tag and will use "latest" by default.