### PR TITLE
chore: add missing endpoint to allow list

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -30,6 +30,7 @@ jobs:
           production.cloudflare.docker.com:443
           registry-1.docker.io:443
           repo.packagist.org:443
+          repo.packagist.org:80
           storage.googleapis.com:443
           auth.docker.io:443
 


### PR DESCRIPTION
The run https://github.com/GoogleCloudPlatform/functions-framework-php/actions/runs/5138700972?pr=145 failed. According to https://app.stepsecurity.io/github/GoogleCloudPlatform/functions-framework-php/actions/runs/5138700972 the action tried to call repo.packagist.org:80 but the endpoint is not part of the allow list.