### PR TITLE
fix: correct content-type headers on typed function response

### DIFF
--- a/src/TypedFunctionWrapper.php
+++ b/src/TypedFunctionWrapper.php
@@ -99,6 +99,6 @@ class TypedFunctionWrapper extends FunctionWrapper
         }
         $resultJson = $funcResult->serializeToJsonString();
 
-        return new Response(200, ['content-type' => 'application/cloudevents+json'], $resultJson);
+        return new Response(200, ['content-type' => 'application/json'], $resultJson);
     }
 }

--- a/tests/TypedFunctionWrapperTest.php
+++ b/tests/TypedFunctionWrapperTest.php
@@ -109,6 +109,7 @@ class TypedFunctionWrapperTest extends TestCase
         $request = new ServerRequest('POST', '/', ['content-type' => 'application/json'], '1');
         $response = $typedFunctionWrapper->execute($request);
         $this->assertSame('2', (string) $response->getBody());
+        $this->assertSame('application/json', $response->getHeaderLine("Content-Type"));
     }
 
     public function testBadRequest(): void


### PR DESCRIPTION
Noticed that the content type header is set incorrectly on the result of a typed function invocation. The expected content type is `application/json`.