### PR TITLE
fix: use full import paths from vendor for new composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ run the following commands:
 
 ```sh
 export FUNCTION_TARGET=helloHttp
-php -S localhost:8080 vendor/bin/router.php
+php -S localhost:8080 vendor/google/cloud-functions-framework/router.php
 ```
 
 Open `http://localhost:8080/` in your browser and see *Hello World from a PHP HTTP function!*.
@@ -231,7 +231,7 @@ variable to `cloudevent`.
 ```sh
 export FUNCTION_TARGET=helloCloudEvent
 export FUNCTION_SIGNATURE_TYPE=cloudevent
-php -S localhost:8080 vendor/bin/router.php
+php -S localhost:8080 vendor/google/cloud-functions-framework/router.php
 ```
 
 In a separate tab, make a cURL request in Cloud Event format to your function:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5|^8.0|^10",
+    "phpunit/phpunit": "^7.5|^8.0",
     "guzzlehttp/guzzle": "^7.2"
   },
   "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5|^8.0",
+    "phpunit/phpunit": "^7.5|^8.0|^10",
     "guzzlehttp/guzzle": "^7.2"
   },
   "autoload-dev": {

--- a/examples/hello/Dockerfile
+++ b/examples/hello/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /srv/
 #
 # We configure it to use the `router.php` file included in this package.
 RUN mkdir .googleconfig && \
-    echo '{"entrypointContents": "serve vendor/bin/router.php"}' > .googleconfig/app_start.json
+    echo '{"entrypointContents": "serve vendor/google/cloud-functions-framework/router.php"}' > .googleconfig/app_start.json
 
 # Copy over composer files and run "composer install"
 COPY composer.* ./

--- a/tests/vendorTest.php
+++ b/tests/vendorTest.php
@@ -178,41 +178,4 @@ class vendorTest extends TestCase
 
         $this->assertSame(['Hello Absolute!'], $output);
     }
-
-    public function testLegacyVendorBinGcsIsNotRegistered(): void
-    {
-        copy(__DIR__ . '/fixtures/gcs.php', self::$tmpDir . '/gcs.php');
-        $cmd = sprintf(
-            'FUNCTION_SOURCE=%s/gcs.php' .
-            ' FUNCTION_SIGNATURE_TYPE=http' .
-            ' FUNCTION_TARGET=helloDefault' .
-            ' php %s/vendor/bin/router.php',
-            self::$tmpDir,
-            self::$tmpDir
-        );
-        exec($cmd, $output);
-
-        $this->assertEquals(['GCS Stream Wrapper is not registered'], $output);
-    }
-
-    /**
-     * @depends testLegacyVendorBinGcsIsNotRegistered
-     */
-    public function testLegacyVendorBinGcsIsRegistered(): void
-    {
-        passthru('composer require -w google/cloud-storage');
-
-        copy(__DIR__ . '/fixtures/gcs.php', self::$tmpDir . '/gcs.php');
-        $cmd = sprintf(
-            'FUNCTION_SOURCE=%s/gcs.php' .
-            ' FUNCTION_SIGNATURE_TYPE=http' .
-            ' FUNCTION_TARGET=helloDefault' .
-            ' php %s/vendor/bin/router.php',
-            self::$tmpDir,
-            self::$tmpDir
-        );
-        exec($cmd, $output);
-
-        $this->assertEquals(['GCS Stream Wrapper is registered'], $output);
-    }
 }

--- a/tests/vendorTest.php
+++ b/tests/vendorTest.php
@@ -57,7 +57,7 @@ class vendorTest extends TestCase
             'FUNCTION_SOURCE=' .
             ' FUNCTION_SIGNATURE_TYPE=http' .
             ' FUNCTION_TARGET=helloDefault' .
-            ' php %s/vendor/bin/router.php',
+            ' php %s/vendor/google/cloud-functions-framework/router.php',
             self::$tmpDir
         );
         exec($cmd, $output);
@@ -72,7 +72,7 @@ class vendorTest extends TestCase
             'FUNCTION_SOURCE=relative.php' .
             ' FUNCTION_SIGNATURE_TYPE=http' .
             ' FUNCTION_TARGET=helloDefault' .
-            ' php %s/vendor/bin/router.php',
+            ' php %s/vendor/google/cloud-functions-framework/router.php',
             self::$tmpDir
         );
         exec($cmd, $output);
@@ -81,6 +81,89 @@ class vendorTest extends TestCase
     }
 
     public function testAbsoluteFunctionSource(): void
+    {
+        copy(__DIR__ . '/fixtures/absolute.php', self::$tmpDir . '/absolute.php');
+        $cmd = sprintf(
+            'FUNCTION_SOURCE=%s/absolute.php' .
+            ' FUNCTION_SIGNATURE_TYPE=http' .
+            ' FUNCTION_TARGET=helloDefault' .
+            ' php %s/vendor/google/cloud-functions-framework/router.php',
+            self::$tmpDir,
+            self::$tmpDir
+        );
+        exec($cmd, $output);
+
+        $this->assertSame(['Hello Absolute!'], $output);
+    }
+
+    public function testGcsIsNotRegistered(): void
+    {
+        copy(__DIR__ . '/fixtures/gcs.php', self::$tmpDir . '/gcs.php');
+        $cmd = sprintf(
+            'FUNCTION_SOURCE=%s/gcs.php' .
+            ' FUNCTION_SIGNATURE_TYPE=http' .
+            ' FUNCTION_TARGET=helloDefault' .
+            ' php %s/vendor/google/cloud-functions-framework/router.php',
+            self::$tmpDir,
+            self::$tmpDir
+        );
+        exec($cmd, $output);
+
+        $this->assertEquals(['GCS Stream Wrapper is not registered'], $output);
+    }
+
+    /**
+     * @depends testGcsIsNotRegistered
+     */
+    public function testGcsIsRegistered(): void
+    {
+        passthru('composer require -w google/cloud-storage');
+
+        copy(__DIR__ . '/fixtures/gcs.php', self::$tmpDir . '/gcs.php');
+        $cmd = sprintf(
+            'FUNCTION_SOURCE=%s/gcs.php' .
+            ' FUNCTION_SIGNATURE_TYPE=http' .
+            ' FUNCTION_TARGET=helloDefault' .
+            ' php %s/vendor/google/cloud-functions-framework/router.php',
+            self::$tmpDir,
+            self::$tmpDir
+        );
+        exec($cmd, $output);
+
+        $this->assertEquals(['GCS Stream Wrapper is registered'], $output);
+    }
+
+    public function testLegacyVendorBinDefaultFunctionSource(): void
+    {
+        copy(__DIR__ . '/fixtures/index.php', self::$tmpDir . '/index.php');
+        $cmd = sprintf(
+            'FUNCTION_SOURCE=' .
+            ' FUNCTION_SIGNATURE_TYPE=http' .
+            ' FUNCTION_TARGET=helloDefault' .
+            ' php %s/vendor/bin/router.php',
+            self::$tmpDir
+        );
+        exec($cmd, $output);
+
+        $this->assertSame(['Hello Default!'], $output);
+    }
+
+    public function testLegacyVendorBinRelativeFunctionSource(): void
+    {
+        copy(__DIR__ . '/fixtures/relative.php', self::$tmpDir . '/relative.php');
+        $cmd = sprintf(
+            'FUNCTION_SOURCE=relative.php' .
+            ' FUNCTION_SIGNATURE_TYPE=http' .
+            ' FUNCTION_TARGET=helloDefault' .
+            ' php %s/vendor/bin/router.php',
+            self::$tmpDir
+        );
+        exec($cmd, $output);
+
+        $this->assertSame(['Hello Relative!'], $output);
+    }
+
+    public function testLegacyVendorBinAbsoluteFunctionSource(): void
     {
         copy(__DIR__ . '/fixtures/absolute.php', self::$tmpDir . '/absolute.php');
         $cmd = sprintf(
@@ -96,7 +179,7 @@ class vendorTest extends TestCase
         $this->assertSame(['Hello Absolute!'], $output);
     }
 
-    public function testGcsIsNotRegistered(): void
+    public function testLegacyVendorBinGcsIsNotRegistered(): void
     {
         copy(__DIR__ . '/fixtures/gcs.php', self::$tmpDir . '/gcs.php');
         $cmd = sprintf(
@@ -113,9 +196,9 @@ class vendorTest extends TestCase
     }
 
     /**
-     * @depends testGcsIsNotRegistered
+     * @depends testLegacyVendorBinGcsIsNotRegistered
      */
-    public function testGcsIsRegistered(): void
+    public function testLegacyVendorBinGcsIsRegistered(): void
     {
         passthru('composer require -w google/cloud-storage');
 


### PR DESCRIPTION
Replace `vendor/bin/router.php` paths with the full `router.php` path in `vendor/`. Starting with composer 2.2, which is in package repos, composer changed the way it was handling the `bin` directive by creating wrapper files with shebangs in `vendor/bin` rather than symlinks. This caused our (incorrect) use of these `bin/` files to break when they're used as a script from `php` because `php` expects the first entry in the file to be `<?php` when passed a script.

The composer in the FF buildpacks is old enough that it doesn't introduce the shebang which is why it still works.

I'm introducing tests to ensure we don't break that until we're safely upgraded the FF buildpack to use the correct router.

Fixes #130