### PR TITLE
fix: Formatting of publishTime date string when none given

### DIFF
--- a/src/LegacyEventMapper.php
+++ b/src/LegacyEventMapper.php
@@ -193,7 +193,7 @@ class LegacyEventMapper
         if (array_key_exists('publishTime', $jsonData['message'])) {
             $timestamp = $jsonData['message']['publishTime'];
         } else {
-            $timestamp = gmdate('%Y-%m-%dT%H:%M:%S.%6NZ');
+            $timestamp = gmdate('Y-m-d\TH:i:s.v\Z');
         }
 
         return [

--- a/tests/LegacyEventMapperTest.php
+++ b/tests/LegacyEventMapperTest.php
@@ -128,7 +128,7 @@ class LegacyEventMapperTest extends TestCase
         );
         $this->assertNull($cloudevent->getSubject());
         $this->assertEqualsWithDelta(
-            strtotime(gmdate('%Y-%m-%dT%H:%M:%S.%6NZ')),
+            strtotime(gmdate('Y-m-d\TH:i:s.v\Z')),
             strtotime($cloudevent->getTime()),
             1
         );
@@ -168,7 +168,7 @@ class LegacyEventMapperTest extends TestCase
         );
         $this->assertNull($cloudevent->getSubject());
         $this->assertEqualsWithDelta(
-            strtotime(gmdate('%Y-%m-%dT%H:%M:%S.%6NZ')),
+            strtotime(gmdate('Y-m-d\TH:i:s.v\Z')),
             strtotime($cloudevent->getTime()),
             1
         );


### PR DESCRIPTION
Use ISO8601 format when the `publishTime` is not provided in the message.

Fixes #167 

