### PR TITLE
feat: change CloudEvent time property from string to object (#66)

### DIFF
--- a/src/CloudEvent.php
+++ b/src/CloudEvent.php
@@ -18,6 +18,8 @@
 
 namespace Google\CloudFunctions;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use JsonSerializable;
 
 class CloudEvent implements JsonSerializable
@@ -32,6 +34,9 @@ class CloudEvent implements JsonSerializable
     private $datacontenttype;
     private $dataschema;
     private $subject;
+    /**
+     * @var DateTimeImmutable|null
+     */
     private $time;
     /**
      * @var mixed $data
@@ -56,7 +61,7 @@ class CloudEvent implements JsonSerializable
         $this->datacontenttype = $datacontenttype;
         $this->dataschema = $dataschema;
         $this->subject = $subject;
-        $this->time = $time;
+        $this->time = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $time) ?: null;
         $this->data = $data;
     }
 
@@ -88,7 +93,7 @@ class CloudEvent implements JsonSerializable
     {
         return $this->subject;
     }
-    public function getTime(): ?string
+    public function getTime(): ?DateTimeImmutable
     {
         return $this->time;
     }
@@ -132,7 +137,7 @@ class CloudEvent implements JsonSerializable
             'datacontenttype' => $this->datacontenttype,
             'dataschema' => $this->dataschema,
             'subject' => $this->subject,
-            'time' => $this->time,
+            'time' => $this->time->format(DateTimeInterface::RFC3339_EXTENDED),
             'data' => $this->data,
         ];
     }
@@ -148,7 +153,7 @@ class CloudEvent implements JsonSerializable
             "- datacontenttype: $this->datacontenttype",
             "- dataschema: $this->dataschema",
             "- subject: $this->subject",
-            "- time: $this->time",
+            "- time: {$this->time->format(DateTimeInterface::RFC3339_EXTENDED)}",
         ]);
         return $output;
     }

--- a/src/CloudEventSdkCompliant.php
+++ b/src/CloudEventSdkCompliant.php
@@ -69,11 +69,7 @@ class CloudEventSdkCompliant implements JsonSerializable, CloudEventInterface
     }
     public function getTime(): ?DateTimeImmutable
     {
-        $time = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->cloudevent->getTime());
-        if ($time === false) {
-            return null;
-        }
-        return $time;
+        return $this->cloudevent->getTime();
     }
     public function getExtension(string $attribute)
     {

--- a/src/LegacyEventMapper.php
+++ b/src/LegacyEventMapper.php
@@ -17,6 +17,8 @@
 
 namespace Google\CloudFunctions;
 
+use DateTime;
+use DateTimeInterface;
 use RuntimeException;
 
 class LegacyEventMapper
@@ -193,7 +195,7 @@ class LegacyEventMapper
         if (array_key_exists('publishTime', $jsonData['message'])) {
             $timestamp = $jsonData['message']['publishTime'];
         } else {
-            $timestamp = gmdate('%Y-%m-%dT%H:%M:%S.%6NZ');
+            $timestamp = gmdate('Y-m-d\TH:i:s.v\Z');
         }
 
         return [

--- a/tests/CloudEventFunctionsWrapperTest.php
+++ b/tests/CloudEventFunctionsWrapperTest.php
@@ -18,6 +18,7 @@
 
 namespace Google\CloudFunctions\Tests;
 
+use DateTimeInterface;
 use Google\CloudFunctions\CloudEventFunctionWrapper;
 use Google\CloudFunctions\CloudEvent;
 use PHPUnit\Framework\TestCase;
@@ -239,7 +240,7 @@ class CloudEventFunctionsWrapperTest extends TestCase
         $this->assertSame('application/json', $cloudevent->getDataContentType());
         $this->assertSame('type.googleapis.com/google.logging.v2.LogEntry', $cloudevent->getDataSchema());
         $this->assertSame('My Subject', $cloudevent->getSubject());
-        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('2020-12-08T20:03:19.162+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
     }
 
     public function testWithNotFullButValidCloudEvent(): void
@@ -306,7 +307,7 @@ class CloudEventFunctionsWrapperTest extends TestCase
         $this->assertSame('application/json', $cloudevent->getDataContentType());
         $this->assertNull($cloudevent->getDataSchema());
         $this->assertNull($cloudevent->getSubject());
-        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('2020-12-08T20:03:19.162+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
     }
 
     public function testFromStructuredEventRequest(): void

--- a/tests/CloudEventSdkCompliantTest.php
+++ b/tests/CloudEventSdkCompliantTest.php
@@ -66,7 +66,7 @@ class CloudEventSdkCompliantTest extends TestCase
     "datacontenttype": "application\/json",
     "dataschema": "type.googleapis.com\/google.logging.v2.LogEntry",
     "subject": "My Subject",
-    "time": "2020-12-08T20:03:19.162Z",
+    "time": "2020-12-08T20:03:19.162+00:00",
     "data": {
         "message": {
             "data": "SGVsbG8gdGhlcmU=",
@@ -91,7 +91,7 @@ class CloudEventSdkCompliantTest extends TestCase
         $this->assertSame($this->cloudevent->getDataContentType(), $wrappedEvent->getDataContentType());
         $this->assertSame($this->cloudevent->getDataSchema(), $wrappedEvent->getDataSchema());
         $this->assertSame($this->cloudevent->getSubject(), $wrappedEvent->getSubject());
-        $this->assertEquals(DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $this->cloudevent->getTime()), $wrappedEvent->getTime());
+        $this->assertSame($this->cloudevent->getTime(), $wrappedEvent->getTime());
     }
 
     public function testUnimplementedGetExtensionThrowsError(): void

--- a/tests/CloudEventTest.php
+++ b/tests/CloudEventTest.php
@@ -55,7 +55,7 @@ class CloudEventTest extends TestCase
     "datacontenttype": "application\/json",
     "dataschema": "type.googleapis.com\/google.logging.v2.LogEntry",
     "subject": "My Subject",
-    "time": "2020-12-08T20:03:19.162Z",
+    "time": "2020-12-08T20:03:19.162+00:00",
     "data": {
         "message": {
             "data": "SGVsbG8gdGhlcmU=",

--- a/tests/LegacyEventMapperTest.php
+++ b/tests/LegacyEventMapperTest.php
@@ -18,6 +18,7 @@
 
 namespace Google\CloudFunctions\Tests;
 
+use DateTimeInterface;
 use Google\CloudFunctions\LegacyEventMapper;
 use PHPUnit\Framework\TestCase;
 use stdClass;
@@ -93,7 +94,7 @@ class LegacyEventMapperTest extends TestCase
         $this->assertSame('application/json', $cloudevent->getDataContentType());
         $this->assertNull($cloudevent->getDataSchema());
         $this->assertNull($cloudevent->getSubject());
-        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('2020-12-08T20:03:19.162+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
 
         // Verify Pub/Sub-specific data transformation.
         $message = $cloudevent->getData()['message'];
@@ -128,8 +129,8 @@ class LegacyEventMapperTest extends TestCase
         );
         $this->assertNull($cloudevent->getSubject());
         $this->assertEqualsWithDelta(
-            strtotime(gmdate('%Y-%m-%dT%H:%M:%S.%6NZ')),
-            strtotime($cloudevent->getTime()),
+            strtotime(gmdate(DateTimeInterface::RFC3339_EXTENDED)),
+            strtotime($cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED)),
             1
         );
         $this->assertSame(
@@ -168,8 +169,8 @@ class LegacyEventMapperTest extends TestCase
         );
         $this->assertNull($cloudevent->getSubject());
         $this->assertEqualsWithDelta(
-            strtotime(gmdate('%Y-%m-%dT%H:%M:%S.%6NZ')),
-            strtotime($cloudevent->getTime()),
+            strtotime(gmdate(DateTimeInterface::RFC3339_EXTENDED)),
+            strtotime($cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED)),
             1
         );
         $this->assertSame(
@@ -207,7 +208,7 @@ class LegacyEventMapperTest extends TestCase
         $this->assertSame('application/json', $cloudevent->getDataContentType());
         $this->assertNull($cloudevent->getDataSchema());
         $this->assertNull($cloudevent->getSubject());
-        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('2020-12-08T20:03:19.162+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
 
         // Verify Pub/Sub-specific data transformation.
         $message = $cloudevent->getData()['message'];
@@ -249,7 +250,7 @@ class LegacyEventMapperTest extends TestCase
             'objects/MyFile#1588778055917163',
             $cloudevent->getSubject()
         );
-        $this->assertSame('2020-12-08T20:03:19.162Z', $cloudevent->getTime());
+        $this->assertSame('2020-12-08T20:03:19.162+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
         $this->assertSame('foo', $cloudevent->getData());
     }
 
@@ -296,7 +297,8 @@ class LegacyEventMapperTest extends TestCase
             'users/UUpby3s4spZre6kHsgVSPetzQ8l2',
             $cloudevent->getSubject()
         );
-        $this->assertSame('2020-09-29T11:32:00.000Z', $cloudevent->getTime());
+        var_dump($cloudevent->getTime());
+        $this->assertSame('2020-09-29T11:32:00.000+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
         $this->assertSame('2020-05-26T10:42:27Z', $cloudevent->getData()['metadata']['createTime']);
         $this->assertSame('2020-10-24T11:00:00Z', $cloudevent->getData()['metadata']['lastSignInTime']);
     }
@@ -341,7 +343,7 @@ class LegacyEventMapperTest extends TestCase
             'refs/gcf-test/xyz',
             $cloudevent->getSubject()
         );
-        $this->assertSame('2020-05-21T11:53:45.337Z', $cloudevent->getTime());
+        $this->assertSame('2020-05-21T11:53:45.337+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
     }
 
     public function testFirebaseAuthDbDeleteWithAlternateDomain(): void
@@ -384,7 +386,7 @@ class LegacyEventMapperTest extends TestCase
             'refs/gcf-test/xyz',
             $cloudevent->getSubject()
         );
-        $this->assertSame('2020-05-21T11:53:45.337Z', $cloudevent->getTime());
+        $this->assertSame('2020-05-21T11:53:45.337+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
     }
 
     public function testFirebaseAuthDbDeleteWithInvalidDomain(): void
@@ -424,6 +426,6 @@ class LegacyEventMapperTest extends TestCase
         $this->assertSame('application/json', $cloudevent->getDataContentType());
         $this->assertNull($cloudevent->getDataSchema());
         $this->assertNull($cloudevent->getSubject());
-        $this->assertSame('2020-05-21T11:53:45.337Z', $cloudevent->getTime());
+        $this->assertSame('2020-05-21T11:53:45.337+00:00', $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED));
     }
 }

--- a/tests/conformance/index.php
+++ b/tests/conformance/index.php
@@ -93,7 +93,7 @@ function fixCloudEventData(CloudEvent $cloudevent): CloudEvent
             $cloudevent->getDatacontenttype(),
             $cloudevent->getDataschema(),
             $cloudevent->getSubject(),
-            $cloudevent->getTime(),
+            $cloudevent->getTime()->format(DateTimeInterface::RFC3339_EXTENDED),
             $data
         );
     }


### PR DESCRIPTION
Closes #66 

Since `Z` and `+00:00` are aliases in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-4.3) and PHP happens to output +00:00 when the `P` (and thus the `RFC3339_EXTENDED`) format character is used, I chose to update the tests accordingly so that the `DateTimeInterface:RFC3339_EXTENDED` can be used. However, if you'd prefer for the tests to stay the same and for the `Z` character to be printed instead of `+00:00`, it will be a simple tweak.