### PR TITLE
feat: add environment variable for configuring max_execution_time

### DIFF
--- a/router.php
+++ b/router.php
@@ -42,6 +42,12 @@ if ($source = $projectContext->locateFunctionSource($functionSourceEnv)) {
 // registered
 $projectContext->registerCloudStorageStreamWrapperIfPossible();
 
+// Initialize timeout, in case configured.
+$custom_timeout = getenv('CLOUD_RUN_TIMEOUT_SECONDS');
+if ($custom_timeout !== false) {
+    set_time_limit($custom_timeout);
+}
+
 /**
  * Invoke the function based on the function type.
  */


### PR DESCRIPTION
In response to a demanded capability. In case of PHP, one may configure `max_execution_time` directly in a similar way, but that's just one language-specific piece of a larger story.