### PR TITLE
Remove $path blocking

### DIFF
--- a/src/HttpFunctionWrapper.php
+++ b/src/HttpFunctionWrapper.php
@@ -54,11 +54,6 @@ class HttpFunctionWrapper extends FunctionWrapper
 
     public function execute(ServerRequestInterface $request): ResponseInterface
     {
-        $path = $request->getUri()->getPath();
-        if ($path == '/robots.txt' || $path == '/favicon.ico') {
-            return new Response(404);
-        }
-
         $response = call_user_func($this->function, $request);
 
         if (is_string($response)) {


### PR DESCRIPTION
The framework should not have any $path blocking, as one might want to use the blocked paths.